### PR TITLE
Add pricing and mobile scheduling updates

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700;800;900&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700;800&display=swap');
 
 :root {
     --academic-navy: #0B1426;
@@ -119,6 +120,10 @@ body {
     font-family: 'Playfair Display', serif;
 }
 
+.logo-font {
+    font-family: 'Montserrat', sans-serif;
+}
+
 @media (max-width: 768px) {
     .academic-card {
         border-radius: 8px;
@@ -129,8 +134,11 @@ body {
     }
 
     .schedule-button {
-        bottom: 15px;
-        right: 15px;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        width: 100%;
+        border-radius: 0;
     }
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import Header from '@/components/Header'
 import Hero from '@/components/Hero'
 import Services from '@/components/Services'
 import About from '@/components/About'
+import Pricing from '@/components/Pricing'
 import FAQ from '@/components/FAQ'
 import Contact from '@/components/Contact'
 import Footer from '@/components/Footer'
@@ -14,6 +15,7 @@ export default function HomePage () {
                 <Hero />
                 <Services />
                 <About />
+                <Pricing />
                 <FAQ />
                 <Contact />
             </main>

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -134,7 +134,6 @@ export default function Contact() {
                         <div className="academic-card p-8">
                             {!scheduleType && !isSubmitted && (
                                 <div className="text-center">
-                                    <h3 className="text-2xl font-bold text-white mb-6 title-font">Choose Your Next Step</h3>
                                     <p className="text-gray-300 mb-8">
                                         Start with a free consultation or schedule your first tutoring session
                                     </p>

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { ChevronDown, ChevronUp, HelpCircle } from 'lucide-react'
+import { siteContent } from '@/data/siteContent'
 
 // FAQ SVG Icon
 const FAQIcon = () => (
@@ -23,32 +24,10 @@ export default function FAQ() {
         setOpenItem(openItem === index ? null : index)
     }
 
-    const faqs: FAQItem[] = [
-        {
-            question: "How do you customize tutoring to work with my current classes?",
-            answer: "I review your current coursework, understand your teachers' methods, and align my tutoring to support what you're learning in class. You get help that directly improves your classroom performance while building stronger foundations."
-        },
-        {
-            question: "What makes your Bay Area knowledge valuable for students?",
-            answer: "I know the teachers, curricula, and academic expectations at local high schools. This means your tutoring directly supports your classroom experience. I can prepare you for specific teacher styles and help you excel in your current environment."
-        },
-        {
-            question: "Do you offer both test prep and academic tutoring?",
-            answer: "Yes. You can get comprehensive support for SAT, ACT, and SAT Subject Tests, plus ongoing help with your high school courses. I create integrated plans that improve both your test scores and classroom grades."
-        },
-        {
-            question: "Where do tutoring sessions take place?",
-            answer: "You choose what works best. I offer sessions at your home, Bay Area libraries, or online. Each location provides a professional learning environment tailored to your preferences and schedule."
-        },
-        {
-            question: "How quickly can I expect to see improvement?",
-            answer: "Most students see improvements within 4-6 weeks of consistent tutoring. Your progress depends on your starting point, goals, and commitment. I track your progress and adjust our approach to ensure steady improvement."
-        },
-        {
-            question: "What's included in the free consultation?",
-            answer: "We discuss your academic goals, review your current challenges, and I explain how I can help you succeed. You'll get a clear understanding of my approach and a preliminary learning plan with no commitment required."
-        }
-    ]
+    const faqs: FAQItem[] = siteContent.faq.items.map(item => ({
+        question: item.question,
+        answer: item.answer
+    }))
 
     return (
         <section id="faq" className="py-20 lg:py-32 bg-academic-dark-blue">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -41,8 +41,8 @@ export default function Header() {
                     <div className="flex items-center justify-between h-16 lg:h-20">
                         {/* Logo */}
                         <div className="flex items-center">
-                            <h1 className="text-xl lg:text-2xl font-bold text-academic-gold title-font">
-                                Bay Area Academic Tutor
+                            <h1 className="text-2xl lg:text-3xl font-extrabold text-academic-gold logo-font tracking-wide drop-shadow">
+                                The Bay Area Tutor
                             </h1>
                         </div>
 
@@ -128,10 +128,10 @@ export default function Header() {
             {/* Floating Schedule Button */}
             <button
                 onClick={handleScheduleClick}
-                className="schedule-button academic-button px-4 py-3 rounded-full flex items-center space-x-2 animate-academic-glow"
+                className="schedule-button academic-button px-4 py-3 rounded-full flex items-center justify-center space-x-2 animate-academic-glow"
             >
                 <Calendar className="w-5 h-5" />
-                <span className="hidden sm:inline font-semibold">Schedule Now</span>
+                <span className="font-semibold">Schedule Now</span>
             </button>
         </>
     )

--- a/src/components/Pricing.tsx
+++ b/src/components/Pricing.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { Calendar } from 'lucide-react'
+import { siteContent } from '@/data/siteContent'
+
+export default function Pricing() {
+    const { subheading, plans } = siteContent.pricing
+
+    const scrollToContact = () => {
+        const element = document.getElementById('contact')
+        if (element) element.scrollIntoView({ behavior: 'smooth' })
+    }
+
+    return (
+        <section id="pricing" className="py-20 lg:py-32 bg-academic-dark-blue">
+            <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+                <div className="text-center mb-16">
+                    <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6 title-font">
+                        <span className="text-white">Investment in</span>
+                        <span className="block text-gradient">Your Child's Future</span>
+                    </h2>
+                    <p className="text-lg sm:text-xl text-gray-300 max-w-3xl mx-auto">
+                        {subheading}
+                    </p>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+                    {plans.map(plan => (
+                        <div key={plan.id} className="academic-card p-8 text-center academic-hover">
+                            <h3 className="text-xl font-bold text-white mb-4 title-font">{plan.name}</h3>
+                            <div className="text-4xl font-bold text-academic-gold mb-4">
+                                ${plan.price}
+                                <span className="text-lg text-gray-300">{plan.unit}</span>
+                            </div>
+                            <ul className="space-y-2 mb-6">
+                                {plan.features.map((feature, idx) => (
+                                    <li key={idx} className="text-gray-300 text-sm">{feature}</li>
+                                ))}
+                            </ul>
+                            <button
+                                onClick={scrollToContact}
+                                className="academic-button w-full px-4 py-3 font-semibold rounded-md flex items-center justify-center space-x-2"
+                            >
+                                <Calendar className="w-4 h-4" />
+                                <span>{plan.cta}</span>
+                            </button>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </section>
+    )
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,6 +25,7 @@ module.exports = {
                 'title': ['Playfair Display', 'serif'],
                 'sans': ['Inter', 'system-ui', 'sans-serif'],
                 'mono': ['JetBrains Mono', 'monospace'],
+                'brand': ['Montserrat', 'sans-serif'],
             },
             animation: {
                 'fade-in': 'fadeIn 0.6s ease-in-out',


### PR DESCRIPTION
## Summary
- Add Montserrat-based logo and full-width mobile scheduling button for clearer calls to action
- Source FAQ items from shared site content and integrate new Pricing section
- Simplify scheduling workflow by removing extra step in contact section

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: space-before-function-paren, array-bracket-spacing)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d08dc5b8832bb1cade18d6fb6137