### PR TITLE
feat: add sleek cal modal and schedule button logic

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import { CalModalProvider } from '@/components/CalModal'
 
 export const metadata: Metadata = {
     title: 'Bay Area Academic Tutoring | SAT, ACT & School Support | Expert Private Tutor',
@@ -80,7 +81,9 @@ export default function RootLayout ({
             />
         </head>
         <body className="bg-academic-navy text-white antialiased">
-        {children}
+        <CalModalProvider>
+            {children}
+        </CalModalProvider>
         </body>
         </html>
     )

--- a/src/components/CalModal.tsx
+++ b/src/components/CalModal.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { createContext, useContext, useState, ReactNode } from 'react'
+import { X } from 'lucide-react'
+
+interface CalModalContextType {
+  open: (link?: string) => void
+  close: () => void
+}
+
+const CalModalContext = createContext<CalModalContextType>({ open: () => {}, close: () => {} })
+
+export const CalModalProvider = ({ children }: { children: ReactNode }) => {
+  const [ isOpen, setIsOpen ] = useState(false)
+  const [ link, setLink ] = useState('https://cal.com/thebayarea/consultation?embed=1')
+
+  const open = (url?: string) => {
+    setLink(url ?? 'https://cal.com/thebayarea/consultation?embed=1')
+    setIsOpen(true)
+  }
+
+  const close = () => setIsOpen(false)
+
+  return (
+    <CalModalContext.Provider value={{ open, close }}>
+      {children}
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
+          <div className="relative w-full max-w-3xl bg-white rounded-xl shadow-2xl overflow-hidden">
+            <button
+              onClick={close}
+              className="absolute top-3 right-3 text-gray-600 hover:text-academic-navy"
+            >
+              <X className="w-5 h-5" />
+            </button>
+            <iframe
+              src={link}
+              className="w-full h-[700px] border-none"
+              title="Schedule with Cal.com"
+            />
+          </div>
+        </div>
+      )}
+    </CalModalContext.Provider>
+  )
+}
+
+export const useCalModal = () => useContext(CalModalContext)

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState } from 'react'
-import { Phone, Mail, Clock, Calendar, User } from 'lucide-react'
+import { Phone, Mail, Clock, Calendar, User, Check } from 'lucide-react'
+import { useCalModal } from '@/components/CalModal'
 
 // Contact SVG Icon
 const ContactIcon = () => (
@@ -11,13 +11,7 @@ const ContactIcon = () => (
 )
 
 export default function Contact () {
-    const [ scheduleType, setScheduleType ] = useState<'consultation' | 'session' | null>(null)
-
-    const getCalLink = () => {
-        return scheduleType === 'consultation'
-            ? 'https://cal.com/thebayareatutor/free-consultation?embed=1'
-            : 'https://cal.com/thebayareatutor/tutoring-session?embed=1'
-    }
+    const { open } = useCalModal()
 
     return (
         <section id="contact" className="py-20 lg:py-32 bg-academic-navy">
@@ -79,25 +73,25 @@ export default function Contact () {
                                 </h3>
                                 <div className="space-y-4">
                                     <div className="flex items-start">
-                                        <div className="w-2 h-2 bg-academic-gold rounded-full mt-2 mr-3 flex-shrink-0"></div>
+                                        <Check className="w-5 h-5 text-academic-gold mr-2 mt-0.5 flex-shrink-0" />
                                         <div className="text-gray-300 text-sm">
                                             <span className="text-white font-medium">Free 30-minute consultation</span> to discuss your goals and challenges
                                         </div>
                                     </div>
                                     <div className="flex items-start">
-                                        <div className="w-2 h-2 bg-academic-gold rounded-full mt-2 mr-3 flex-shrink-0"></div>
+                                        <Check className="w-5 h-5 text-academic-gold mr-2 mt-0.5 flex-shrink-0" />
                                         <div className="text-gray-300 text-sm">
                                             <span className="text-white font-medium">Personalized learning plan</span> that works with your school curriculum
                                         </div>
                                     </div>
                                     <div className="flex items-start">
-                                        <div className="w-2 h-2 bg-academic-gold rounded-full mt-2 mr-3 flex-shrink-0"></div>
+                                        <Check className="w-5 h-5 text-academic-gold mr-2 mt-0.5 flex-shrink-0" />
                                         <div className="text-gray-300 text-sm">
                                             <span className="text-white font-medium">Flexible scheduling</span> for your busy lifestyle
                                         </div>
                                     </div>
                                     <div className="flex items-start">
-                                        <div className="w-2 h-2 bg-academic-gold rounded-full mt-2 mr-3 flex-shrink-0"></div>
+                                        <Check className="w-5 h-5 text-academic-gold mr-2 mt-0.5 flex-shrink-0" />
                                         <div className="text-gray-300 text-sm">
                                             <span className="text-white font-medium">Ongoing support</span> between sessions via email
                                         </div>
@@ -107,46 +101,31 @@ export default function Contact () {
                         </div>
 
                         {/* Scheduling Section */}
-                        <div className="academic-card p-8">
-                            {!scheduleType && (
-                                <div className="text-center">
-                                    <p className="text-gray-300 mb-8">
-                                        Start with a free consultation or schedule your first tutoring session
-                                    </p>
+                        <div className="academic-card p-8 flex flex-col justify-between">
+                            <div className="text-center">
+                                <p className="text-gray-300 mb-8">
+                                    Start with a free consultation or schedule your first tutoring session
+                                </p>
 
-                                    <div className="space-y-4">
-                                        <button
-                                            onClick={() => setScheduleType('consultation')}
-                                            className="w-full academic-button px-6 py-4 text-lg font-semibold rounded-lg flex items-center justify-center space-x-2"
-                                        >
-                                            <Calendar className="w-5 h-5" />
-                                            <span>Schedule Free Consultation</span>
-                                        </button>
-
-                                        <button
-                                            onClick={() => setScheduleType('session')}
-                                            className="w-full px-6 py-4 text-lg font-semibold rounded-lg border-2 border-academic-gold/30 hover:border-academic-gold/60 text-white hover:bg-academic-gold/10 transition-all duration-300"
-                                        >
-                                            Schedule Tutoring Session
-                                        </button>
-                                    </div>
-                                </div>
-                            )}
-
-                            {scheduleType && (
                                 <div className="space-y-4">
-                                    <iframe
-                                        src={getCalLink()}
-                                        className="w-full h-[700px] border-none rounded-md"
-                                    ></iframe>
                                     <button
-                                        onClick={() => setScheduleType(null)}
-                                        className="px-6 py-3 text-lg font-semibold rounded-lg border-2 border-white/20 hover:border-academic-gold/50 text-white hover:bg-academic-gold/10 transition-all duration-300"
+                                        data-schedule
+                                        onClick={() => open('https://cal.com/thebayarea/consultation?embed=1')}
+                                        className="w-full academic-button px-6 py-4 text-lg font-semibold rounded-lg flex items-center justify-center space-x-2"
                                     >
-                                        Back
+                                        <Calendar className="w-5 h-5" />
+                                        <span>Schedule Free Consultation</span>
+                                    </button>
+
+                                    <button
+                                        data-schedule
+                                        onClick={() => open('https://cal.com/thebayarea/consultation?embed=1')}
+                                        className="w-full px-6 py-4 text-lg font-semibold rounded-lg border-2 border-academic-gold/30 hover:border-academic-gold/60 text-white hover:bg-academic-gold/10 transition-all duration-300"
+                                    >
+                                        Schedule Tutoring Session
                                     </button>
                                 </div>
-                            )}
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import { Phone, Mail, GraduationCap, ArrowUp, MapPin, Calendar } from 'lucide-react'
+import { useCalModal } from '@/components/CalModal'
 
 export default function Footer () {
     const scrollToTop = () => {
         window.scrollTo({ top: 0, behavior: 'smooth' })
     }
 
+    const { open } = useCalModal()
     const scrollToSection = (sectionId: string) => {
         const element = document.getElementById(sectionId)
         if (element) {
@@ -110,7 +112,8 @@ export default function Footer () {
                         </div>
                         <div className="flex flex-col sm:flex-row items-center gap-4">
                             <button
-                                onClick={() => scrollToSection('contact')}
+                                data-schedule
+                                onClick={() => open('https://cal.com/thebayarea/consultation?embed=1')}
                                 className="academic-button px-6 py-3 font-semibold rounded-lg flex items-center space-x-2"
                             >
                                 <Calendar className="w-4 h-4" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { Menu, X, Calendar } from 'lucide-react'
+import { useCalModal } from '@/components/CalModal'
 
 export default function Header () {
     const [ isScrolled, setIsScrolled ] = useState(false)
@@ -24,9 +25,30 @@ export default function Header () {
         }
     }
 
+    const { open } = useCalModal()
     const handleScheduleClick = () => {
-        scrollToSection('contact')
+        open('https://cal.com/thebayarea/consultation?embed=1')
     }
+
+    const [ showFloating, setShowFloating ] = useState(true)
+
+    useEffect(() => {
+        const checkButtons = () => {
+            const buttons = document.querySelectorAll('[data-schedule]')
+            const anyVisible = Array.from(buttons).some((btn) => {
+                const rect = btn.getBoundingClientRect()
+                return rect.top < window.innerHeight && rect.bottom > 0
+            })
+            setShowFloating(!anyVisible)
+        }
+        checkButtons()
+        window.addEventListener('scroll', checkButtons)
+        window.addEventListener('resize', checkButtons)
+        return () => {
+            window.removeEventListener('scroll', checkButtons)
+            window.removeEventListener('resize', checkButtons)
+        }
+    }, [ ])
 
     return (
         <>
@@ -67,6 +89,7 @@ export default function Header () {
                                 FAQ
                             </button>
                             <button
+                                data-schedule
                                 onClick={handleScheduleClick}
                                 className="academic-button px-6 py-2 text-sm font-semibold rounded-md flex items-center space-x-2"
                             >
@@ -106,6 +129,7 @@ export default function Header () {
                                 FAQ
                             </button>
                             <button
+                                data-schedule
                                 onClick={handleScheduleClick}
                                 className="academic-button w-full px-4 py-2 text-sm font-semibold rounded-md flex items-center justify-center space-x-2"
                             >
@@ -118,13 +142,15 @@ export default function Header () {
             </header>
 
             {/* Floating Schedule Button */}
-            <button
-                onClick={handleScheduleClick}
-                className="schedule-button academic-button px-4 py-3 rounded-full flex items-center justify-center space-x-2 animate-academic-glow"
-            >
-                <Calendar className="w-5 h-5" />
-                <span className="font-semibold">Schedule Now</span>
-            </button>
+            {showFloating && (
+                <button
+                    onClick={handleScheduleClick}
+                    className="schedule-button academic-button px-4 py-3 rounded-full flex items-center justify-center space-x-2 animate-academic-glow"
+                >
+                    <Calendar className="w-5 h-5" />
+                    <span className="font-semibold">Schedule Now</span>
+                </button>
+            )}
         </>
     )
 }

--- a/src/components/ui/PricingCard.tsx
+++ b/src/components/ui/PricingCard.tsx
@@ -7,18 +7,18 @@ interface PricingCardProps {
 
 const PricingCard = ({ plan }: PricingCardProps) => {
     return (
-        <div className={`
-      bg-white rounded-lg shadow-lg overflow-hidden border
-      ${plan.popular ? 'border-yellow-500 transform scale-105 z-10' : 'border-gray-200'}
-      transition-all hover:shadow-xl
-    `}>
+        <div
+            className={`relative bg-white rounded-lg shadow-lg overflow-hidden border-2 ${
+                plan.popular ? 'border-academic-gold scale-105 z-10' : 'border-gray-200'
+            } transition-all hover:shadow-xl flex flex-col`}
+        >
             {plan.popular && (
-                <div className="bg-yellow-600 text-white text-center py-1 text-sm font-medium">
+                <span className="absolute -top-3 left-1/2 -translate-x-1/2 bg-academic-gold text-white text-xs font-semibold px-3 py-1 rounded-full shadow-md">
                     Most Popular
-                </div>
+                </span>
             )}
 
-            <div className="p-6">
+            <div className="p-6 flex flex-col h-full">
                 <h3 className="text-xl font-bold text-navy-800 mb-2">{plan.name}</h3>
 
                 <div className="flex items-baseline mb-6">
@@ -26,10 +26,10 @@ const PricingCard = ({ plan }: PricingCardProps) => {
                     <span className="text-gray-600 ml-1">{plan.unit}</span>
                 </div>
 
-                <ul className="space-y-3 mb-8">
+                <ul className="space-y-3 mb-8 flex-1">
                     {plan.features.map((feature, index) => (
                         <li key={index} className="flex items-start">
-                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-yellow-600 mr-2 mt-0.5 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-academic-gold mr-2 mt-0.5 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
                                 <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                             </svg>
                             <span className="text-gray-700">{feature}</span>
@@ -37,13 +37,11 @@ const PricingCard = ({ plan }: PricingCardProps) => {
                     ))}
                 </ul>
 
-                <Button
-                    variant={plan.popular ? 'primary' : 'outline'}
-                    fullWidth
-                    href="#schedule"
-                >
-                    {plan.cta}
-                </Button>
+                <div className="mt-auto">
+                    <Button variant={plan.popular ? 'primary' : 'outline'} fullWidth href="#schedule">
+                        {plan.cta}
+                    </Button>
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- introduce CalModal provider with blurred backdrop for scheduling via Cal.com
- highlight popular pricing with full border and centered badge
- open Cal modal from schedule buttons and hide floating button when another is visible

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6b54e510c832b9c8dcdd2d64cc19e