### PR TITLE
Add sleek Cal.com modal and unify schedule buttons

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import { ScheduleModalProvider } from '@/components/ScheduleModal'
 
 export const metadata: Metadata = {
     title: 'Bay Area Academic Tutoring | SAT, ACT & School Support | Expert Private Tutor',
@@ -80,7 +81,9 @@ export default function RootLayout ({
             />
         </head>
         <body className="bg-academic-navy text-white antialiased">
-        {children}
+        <ScheduleModalProvider>
+            {children}
+        </ScheduleModalProvider>
         </body>
         </html>
     )

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -2,6 +2,7 @@
 
 import { GraduationCap, Award, Users, TrendingUp, Clock, Target, School, MapPin } from 'lucide-react'
 import { siteContent } from '@/data/siteContent'
+import { useScheduleModal } from '@/components/ScheduleModal'
 
 // Teaching Philosophy SVG Icon
 const TeachingIcon = () => (
@@ -19,6 +20,7 @@ const ExperienceIcon = () => (
 
 export default function About () {
     const expertise = siteContent.about.expertise
+    const { open: openSchedule } = useScheduleModal()
 
     const achievements = [
         { icon: <GraduationCap className="w-6 h-6" />, stat: "UC Berkeley", label: "Graduate" },
@@ -170,10 +172,8 @@ export default function About () {
                                 You get the best tutoring support in the Bay Area. Let's discuss your goals and create a plan for your academic success.
                             </p>
                             <button
-                                onClick={() => {
-                                    const element = document.getElementById('contact')
-                                    if (element) element.scrollIntoView({ behavior: 'smooth' })
-                                }}
+                                data-schedule-trigger
+                                onClick={openSchedule}
                                 className="academic-button px-8 py-3 text-lg font-semibold rounded-lg"
                             >
                                 Schedule Your Free Consultation

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState } from 'react'
 import { Phone, Mail, Clock, Calendar, User } from 'lucide-react'
+import { useScheduleModal } from '@/components/ScheduleModal'
 
 // Contact SVG Icon
 const ContactIcon = () => (
@@ -11,13 +11,7 @@ const ContactIcon = () => (
 )
 
 export default function Contact () {
-    const [ scheduleType, setScheduleType ] = useState<'consultation' | 'session' | null>(null)
-
-    const getCalLink = () => {
-        return scheduleType === 'consultation'
-            ? 'https://cal.com/thebayareatutor/free-consultation?embed=1'
-            : 'https://cal.com/thebayareatutor/tutoring-session?embed=1'
-    }
+    const { open: openSchedule } = useScheduleModal()
 
     return (
         <section id="contact" className="py-20 lg:py-32 bg-academic-navy">
@@ -107,46 +101,18 @@ export default function Contact () {
                         </div>
 
                         {/* Scheduling Section */}
-                        <div className="academic-card p-8">
-                            {!scheduleType && (
-                                <div className="text-center">
-                                    <p className="text-gray-300 mb-8">
-                                        Start with a free consultation or schedule your first tutoring session
-                                    </p>
-
-                                    <div className="space-y-4">
-                                        <button
-                                            onClick={() => setScheduleType('consultation')}
-                                            className="w-full academic-button px-6 py-4 text-lg font-semibold rounded-lg flex items-center justify-center space-x-2"
-                                        >
-                                            <Calendar className="w-5 h-5" />
-                                            <span>Schedule Free Consultation</span>
-                                        </button>
-
-                                        <button
-                                            onClick={() => setScheduleType('session')}
-                                            className="w-full px-6 py-4 text-lg font-semibold rounded-lg border-2 border-academic-gold/30 hover:border-academic-gold/60 text-white hover:bg-academic-gold/10 transition-all duration-300"
-                                        >
-                                            Schedule Tutoring Session
-                                        </button>
-                                    </div>
-                                </div>
-                            )}
-
-                            {scheduleType && (
-                                <div className="space-y-4">
-                                    <iframe
-                                        src={getCalLink()}
-                                        className="w-full h-[700px] border-none rounded-md"
-                                    ></iframe>
-                                    <button
-                                        onClick={() => setScheduleType(null)}
-                                        className="px-6 py-3 text-lg font-semibold rounded-lg border-2 border-white/20 hover:border-academic-gold/50 text-white hover:bg-academic-gold/10 transition-all duration-300"
-                                    >
-                                        Back
-                                    </button>
-                                </div>
-                            )}
+                        <div className="academic-card p-8 flex flex-col">
+                            <p className="text-gray-300 mb-8 text-center">
+                                Start with a free consultation or schedule your first tutoring session
+                            </p>
+                            <button
+                                data-schedule-trigger
+                                onClick={openSchedule}
+                                className="mt-auto w-full academic-button px-6 py-4 text-lg font-semibold rounded-lg flex items-center justify-center space-x-2"
+                            >
+                                <Calendar className="w-5 h-5" />
+                                <span>Schedule Now</span>
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,11 +1,14 @@
 'use client'
 
 import { Phone, Mail, GraduationCap, ArrowUp, MapPin, Calendar } from 'lucide-react'
+import { useScheduleModal } from '@/components/ScheduleModal'
 
 export default function Footer () {
     const scrollToTop = () => {
         window.scrollTo({ top: 0, behavior: 'smooth' })
     }
+
+    const { open: openSchedule } = useScheduleModal()
 
     const scrollToSection = (sectionId: string) => {
         const element = document.getElementById(sectionId)
@@ -79,7 +82,8 @@ export default function Footer () {
                             </li>
                             <li>
                                 <button
-                                    onClick={() => scrollToSection('contact')}
+                                    data-schedule-trigger
+                                    onClick={openSchedule}
                                     className="text-gray-400 hover:text-academic-gold transition-colors text-sm"
                                 >
                                     Free Consultation
@@ -110,7 +114,8 @@ export default function Footer () {
                         </div>
                         <div className="flex flex-col sm:flex-row items-center gap-4">
                             <button
-                                onClick={() => scrollToSection('contact')}
+                                data-schedule-trigger
+                                onClick={openSchedule}
                                 className="academic-button px-6 py-3 font-semibold rounded-lg flex items-center space-x-2"
                             >
                                 <Calendar className="w-4 h-4" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,10 +2,13 @@
 
 import { useState, useEffect } from 'react'
 import { Menu, X, Calendar } from 'lucide-react'
+import { useScheduleModal } from '@/components/ScheduleModal'
 
 export default function Header () {
     const [ isScrolled, setIsScrolled ] = useState(false)
     const [ isMobileMenuOpen, setIsMobileMenuOpen ] = useState(false)
+    const [ showFloating, setShowFloating ] = useState(true)
+    const { open: openSchedule } = useScheduleModal()
 
     useEffect(() => {
         const handleScroll = () => {
@@ -24,8 +27,20 @@ export default function Header () {
         }
     }
 
+    useEffect(() => {
+        const observer = new IntersectionObserver(entries => {
+            const visible = entries.some(entry => entry.isIntersecting)
+            setShowFloating(!visible)
+        })
+        const buttons = document.querySelectorAll('[data-schedule-trigger]:not(.floating)')
+        buttons.forEach(btn => observer.observe(btn))
+        return () => {
+            buttons.forEach(btn => observer.unobserve(btn))
+        }
+    }, [isMobileMenuOpen])
+
     const handleScheduleClick = () => {
-        scrollToSection('contact')
+        openSchedule()
     }
 
     return (
@@ -67,6 +82,7 @@ export default function Header () {
                                 FAQ
                             </button>
                             <button
+                                data-schedule-trigger
                                 onClick={handleScheduleClick}
                                 className="academic-button px-6 py-2 text-sm font-semibold rounded-md flex items-center space-x-2"
                             >
@@ -106,6 +122,7 @@ export default function Header () {
                                 FAQ
                             </button>
                             <button
+                                data-schedule-trigger
                                 onClick={handleScheduleClick}
                                 className="academic-button w-full px-4 py-2 text-sm font-semibold rounded-md flex items-center justify-center space-x-2"
                             >
@@ -118,13 +135,16 @@ export default function Header () {
             </header>
 
             {/* Floating Schedule Button */}
-            <button
-                onClick={handleScheduleClick}
-                className="schedule-button academic-button px-4 py-3 rounded-full flex items-center justify-center space-x-2 animate-academic-glow"
-            >
-                <Calendar className="w-5 h-5" />
-                <span className="font-semibold">Schedule Now</span>
-            </button>
+            {showFloating && (
+                <button
+                    data-schedule-trigger
+                    onClick={handleScheduleClick}
+                    className="floating schedule-button academic-button px-4 py-3 rounded-full flex items-center justify-center space-x-2 animate-academic-glow"
+                >
+                    <Calendar className="w-5 h-5" />
+                    <span className="font-semibold">Schedule Now</span>
+                </button>
+            )}
         </>
     )
 }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ArrowRight, Star, MapPin, GraduationCap } from 'lucide-react'
+import { useScheduleModal } from '@/components/ScheduleModal'
 
 // Academic Achievement SVG Icon
 const AcademicIcon = () => (
@@ -10,12 +11,7 @@ const AcademicIcon = () => (
 )
 
 export default function Hero () {
-    const scrollToContact = () => {
-        const element = document.getElementById('contact')
-        if (element) {
-            element.scrollIntoView({ behavior: 'smooth' })
-        }
-    }
+    const { open: openSchedule } = useScheduleModal()
 
     return (
         <section className="relative min-h-screen flex items-center justify-center overflow-hidden">
@@ -61,7 +57,8 @@ export default function Hero () {
                     {/* CTA Buttons */}
                     <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-12 animate-slide-up delay-400">
                         <button
-                            onClick={scrollToContact}
+                            data-schedule-trigger
+                            onClick={openSchedule}
                             className="academic-button px-8 py-4 text-lg font-semibold rounded-lg flex items-center space-x-2 w-full sm:w-auto"
                         >
                             <span>Schedule Free Consultation</span>

--- a/src/components/Pricing.tsx
+++ b/src/components/Pricing.tsx
@@ -2,14 +2,11 @@
 
 import { Calendar } from 'lucide-react'
 import { siteContent } from '@/data/siteContent'
+import { useScheduleModal } from '@/components/ScheduleModal'
 
 export default function Pricing () {
     const { subheading, plans } = siteContent.pricing
-
-    const scrollToContact = () => {
-        const element = document.getElementById('contact')
-        if (element) element.scrollIntoView({ behavior: 'smooth' })
-    }
+    const { open: openSchedule } = useScheduleModal()
 
     return (
         <section id="pricing" className="py-20 lg:py-32 bg-academic-dark-blue">
@@ -28,10 +25,10 @@ export default function Pricing () {
                     {plans.map(plan => (
                         <div
                             key={plan.id}
-                            className={`academic-card p-8 text-center academic-hover relative ${plan.popular ? 'border-2 border-academic-gold' : ''}`}
+                            className={`academic-card p-8 text-center academic-hover relative flex flex-col h-full ${plan.popular ? 'border-2 border-academic-gold' : ''}`}
                         >
                             {plan.popular && (
-                                <span className="absolute top-4 right-4 bg-academic-gold text-academic-navy text-xs font-semibold px-3 py-1 rounded-full">
+                                <span className="absolute top-4 right-4 px-3 py-1 text-xs font-semibold text-academic-gold border border-academic-gold rounded-full bg-academic-navy/80 backdrop-blur">
                                     Most Popular
                                 </span>
                             )}
@@ -40,14 +37,18 @@ export default function Pricing () {
                                 ${plan.price}
                                 <span className="text-lg text-gray-300">{plan.unit}</span>
                             </div>
-                            <ul className="space-y-2 mb-6">
+                            <ul className="space-y-2 mb-6 text-left flex-grow">
                                 {plan.features.map((feature, idx) => (
-                                    <li key={idx} className="text-gray-300 text-sm">{feature}</li>
+                                    <li key={idx} className="flex items-start text-gray-300 text-sm">
+                                        <div className="w-2 h-2 bg-academic-gold rounded-full mr-3 mt-1 flex-shrink-0"></div>
+                                        <span>{feature}</span>
+                                    </li>
                                 ))}
                             </ul>
                             <button
-                                onClick={scrollToContact}
-                                className="academic-button w-full px-4 py-3 font-semibold rounded-md flex items-center justify-center space-x-2"
+                                data-schedule-trigger
+                                onClick={openSchedule}
+                                className="mt-auto academic-button w-full px-4 py-3 font-semibold rounded-md flex items-center justify-center space-x-2"
                             >
                                 <Calendar className="w-4 h-4" />
                                 <span>{plan.cta}</span>

--- a/src/components/ScheduleModal.tsx
+++ b/src/components/ScheduleModal.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { createContext, useContext, useState, ReactNode, useEffect } from 'react'
+import { X } from 'lucide-react'
+
+interface ScheduleModalContext {
+  open: () => void
+  close: () => void
+}
+
+const ScheduleModalContext = createContext<ScheduleModalContext | undefined>(undefined)
+
+export const useScheduleModal = () => {
+  const ctx = useContext(ScheduleModalContext)
+  if (!ctx) {
+    throw new Error('useScheduleModal must be used within ScheduleModalProvider')
+  }
+  return ctx
+}
+
+export const ScheduleModalProvider = ({ children }: { children: ReactNode }) => {
+  const [ isOpen, setIsOpen ] = useState(false)
+
+  const open = () => setIsOpen(true)
+  const close = () => setIsOpen(false)
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.classList.add('overflow-hidden')
+    } else {
+      document.body.classList.remove('overflow-hidden')
+    }
+  }, [isOpen])
+
+  return (
+    <ScheduleModalContext.Provider value={{ open, close }}>
+      {children}
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={close} />
+          <div className="relative bg-white rounded-xl shadow-2xl w-full max-w-3xl h-[80vh] overflow-hidden">
+            <button onClick={close} className="absolute top-4 right-4 text-gray-500 hover:text-gray-700">
+              <X className="w-5 h-5" />
+            </button>
+            <iframe
+              src="https://cal.com/thebayarea/consultation?embed=1"
+              className="w-full h-full border-none"
+            />
+          </div>
+        </div>
+      )}
+    </ScheduleModalContext.Provider>
+  )
+}
+

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -142,7 +142,7 @@ export default function Services () {
                             className={`academic-card p-8 text-center academic-hover relative ${location.popular ? 'border-2 border-academic-gold' : ''}`}
                         >
                             {location.popular && (
-                                <span className="absolute top-4 right-4 bg-academic-gold text-academic-navy text-xs font-semibold px-3 py-1 rounded-full">
+                                <span className="absolute top-4 right-4 px-3 py-1 text-xs font-semibold text-academic-gold border border-academic-gold rounded-full bg-academic-navy/80 backdrop-blur">
                                     Most Popular
                                 </span>
                             )}

--- a/src/components/ui/PricingCard.tsx
+++ b/src/components/ui/PricingCard.tsx
@@ -13,7 +13,7 @@ const PricingCard = ({ plan }: PricingCardProps) => {
       transition-all hover:shadow-xl
     `}>
             {plan.popular && (
-                <div className="bg-yellow-600 text-white text-center py-1 text-sm font-medium">
+                <div className="text-center py-1 text-sm font-medium text-yellow-600 border border-yellow-600">
                     Most Popular
                 </div>
             )}


### PR DESCRIPTION
## Summary
- Add reusable ScheduleModal with blurred background using Cal.com embed
- Convert schedule buttons to open modal and hide floating button when others visible
- Restyle "Most Popular" tags with bordered badges and normalize bullet lists

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6b54e510c832b9c8dcdd2d64cc19e