### PR TITLE
Add sleek Cal scheduling modal and refine layout symmetry

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import { CalProvider } from '@/components/CalProvider'
 
 export const metadata: Metadata = {
     title: 'Bay Area Academic Tutoring | SAT, ACT & School Support | Expert Private Tutor',
@@ -80,7 +81,9 @@ export default function RootLayout ({
             />
         </head>
         <body className="bg-academic-navy text-white antialiased">
-        {children}
+        <CalProvider>
+            {children}
+        </CalProvider>
         </body>
         </html>
     )

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -2,6 +2,7 @@
 
 import { GraduationCap, Award, Users, TrendingUp, Clock, Target, School, MapPin } from 'lucide-react'
 import { siteContent } from '@/data/siteContent'
+import { useCal } from './CalProvider'
 
 // Teaching Philosophy SVG Icon
 const TeachingIcon = () => (
@@ -18,6 +19,7 @@ const ExperienceIcon = () => (
 )
 
 export default function About () {
+    const { open } = useCal()
     const expertise = siteContent.about.expertise
 
     const achievements = [
@@ -138,21 +140,21 @@ export default function About () {
                             </div>
                             <div className="space-y-6">
                                 <div className="flex items-start space-x-4">
-                                    <div className="w-3 h-3 bg-academic-gold rounded-full mt-1 flex-shrink-0"></div>
+                                    <div className="w-2 h-2 bg-academic-gold rounded-full mt-1 flex-shrink-0"></div>
                                     <div>
                                         <div className="text-white font-semibold mb-1">Private Tutoring</div>
                                         <div className="text-gray-400 text-sm">One-on-one academic support in homes and libraries</div>
                                     </div>
                                 </div>
                                 <div className="flex items-start space-x-4">
-                                    <div className="w-3 h-3 bg-academic-gold rounded-full mt-1 flex-shrink-0"></div>
+                                    <div className="w-2 h-2 bg-academic-gold rounded-full mt-1 flex-shrink-0"></div>
                                     <div>
                                         <div className="text-white font-semibold mb-1">Tutoring Centers</div>
                                         <div className="text-gray-400 text-sm">Professional tutoring experience at established locations</div>
                                     </div>
                                 </div>
                                 <div className="flex items-start space-x-4">
-                                    <div className="w-3 h-3 bg-academic-gold rounded-full mt-1 flex-shrink-0"></div>
+                                    <div className="w-2 h-2 bg-academic-gold rounded-full mt-1 flex-shrink-0"></div>
                                     <div>
                                         <div className="text-white font-semibold mb-1">Curriculum Expertise</div>
                                         <div className="text-gray-400 text-sm">Deep knowledge of Bay Area school programs and standards</div>
@@ -170,11 +172,8 @@ export default function About () {
                                 You get the best tutoring support in the Bay Area. Let's discuss your goals and create a plan for your academic success.
                             </p>
                             <button
-                                onClick={() => {
-                                    const element = document.getElementById('contact')
-                                    if (element) element.scrollIntoView({ behavior: 'smooth' })
-                                }}
-                                className="academic-button px-8 py-3 text-lg font-semibold rounded-lg"
+                                onClick={() => open()}
+                                className="schedule-trigger academic-button px-8 py-3 text-lg font-semibold rounded-lg"
                             >
                                 Schedule Your Free Consultation
                             </button>

--- a/src/components/CalModal.tsx
+++ b/src/components/CalModal.tsx
@@ -1,0 +1,27 @@
+'use client'
+import { X } from 'lucide-react'
+
+interface CalModalProps {
+  onClose: () => void
+}
+
+export default function CalModal({ onClose }: CalModalProps) {
+  return (
+    <div className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/60 backdrop-blur-md p-4">
+      <div className="w-full max-w-3xl h-[80vh] bg-white rounded-lg overflow-hidden relative">
+        <button
+          onClick={onClose}
+          className="absolute top-3 right-3 text-gray-600 hover:text-gray-800"
+          aria-label="Close schedule modal"
+        >
+          <X className="w-6 h-6" />
+        </button>
+        <iframe
+          src="https://cal.com/thebayarea/consultation?embed=1"
+          className="w-full h-full border-0"
+          title="Schedule consultation"
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/CalProvider.tsx
+++ b/src/components/CalProvider.tsx
@@ -1,0 +1,30 @@
+'use client'
+import { createContext, useContext, useState, ReactNode, useEffect } from 'react'
+import CalModal from './CalModal'
+
+interface CalContextValue {
+  open: () => void
+  close: () => void
+}
+
+const CalContext = createContext<CalContextValue | undefined>(undefined)
+
+export function CalProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const open = () => setIsOpen(true)
+  const close = () => setIsOpen(false)
+
+  return (
+    <CalContext.Provider value={{ open, close }}>
+      {children}
+      {isOpen && <CalModal onClose={close} />}
+    </CalContext.Provider>
+  )
+}
+
+export function useCal() {
+  const ctx = useContext(CalContext)
+  if (!ctx) throw new Error('useCal must be used within CalProvider')
+  return ctx
+}

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState } from 'react'
 import { Phone, Mail, Clock, Calendar, User } from 'lucide-react'
+import { useCal } from './CalProvider'
 
 // Contact SVG Icon
 const ContactIcon = () => (
@@ -11,13 +11,7 @@ const ContactIcon = () => (
 )
 
 export default function Contact () {
-    const [ scheduleType, setScheduleType ] = useState<'consultation' | 'session' | null>(null)
-
-    const getCalLink = () => {
-        return scheduleType === 'consultation'
-            ? 'https://cal.com/thebayareatutor/free-consultation?embed=1'
-            : 'https://cal.com/thebayareatutor/tutoring-session?embed=1'
-    }
+    const { open } = useCal()
 
     return (
         <section id="contact" className="py-20 lg:py-32 bg-academic-navy">
@@ -107,46 +101,17 @@ export default function Contact () {
                         </div>
 
                         {/* Scheduling Section */}
-                        <div className="academic-card p-8">
-                            {!scheduleType && (
-                                <div className="text-center">
-                                    <p className="text-gray-300 mb-8">
-                                        Start with a free consultation or schedule your first tutoring session
-                                    </p>
-
-                                    <div className="space-y-4">
-                                        <button
-                                            onClick={() => setScheduleType('consultation')}
-                                            className="w-full academic-button px-6 py-4 text-lg font-semibold rounded-lg flex items-center justify-center space-x-2"
-                                        >
-                                            <Calendar className="w-5 h-5" />
-                                            <span>Schedule Free Consultation</span>
-                                        </button>
-
-                                        <button
-                                            onClick={() => setScheduleType('session')}
-                                            className="w-full px-6 py-4 text-lg font-semibold rounded-lg border-2 border-academic-gold/30 hover:border-academic-gold/60 text-white hover:bg-academic-gold/10 transition-all duration-300"
-                                        >
-                                            Schedule Tutoring Session
-                                        </button>
-                                    </div>
-                                </div>
-                            )}
-
-                            {scheduleType && (
-                                <div className="space-y-4">
-                                    <iframe
-                                        src={getCalLink()}
-                                        className="w-full h-[700px] border-none rounded-md"
-                                    ></iframe>
-                                    <button
-                                        onClick={() => setScheduleType(null)}
-                                        className="px-6 py-3 text-lg font-semibold rounded-lg border-2 border-white/20 hover:border-academic-gold/50 text-white hover:bg-academic-gold/10 transition-all duration-300"
-                                    >
-                                        Back
-                                    </button>
-                                </div>
-                            )}
+                        <div className="academic-card p-8 flex flex-col justify-center text-center">
+                            <p className="text-gray-300 mb-6">
+                                Ready to get started? Schedule a free consultation to discuss your goals.
+                            </p>
+                            <button
+                                onClick={open}
+                                className="schedule-trigger academic-button px-6 py-4 text-lg font-semibold rounded-lg flex items-center justify-center space-x-2 mx-auto"
+                            >
+                                <Calendar className="w-5 h-5" />
+                                <span>Schedule Now</span>
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { Menu, X, Calendar } from 'lucide-react'
+import { useCal } from './CalProvider'
 
 export default function Header () {
     const [ isScrolled, setIsScrolled ] = useState(false)
@@ -24,9 +25,30 @@ export default function Header () {
         }
     }
 
+    const { open } = useCal()
+
     const handleScheduleClick = () => {
-        scrollToSection('contact')
+        open()
+        setIsMobileMenuOpen(false)
     }
+
+    const [ showFloating, setShowFloating ] = useState(true)
+
+    useEffect(() => {
+        const triggers = document.querySelectorAll('.schedule-trigger')
+        const visibleMap = new Map<Element, boolean>()
+
+        const observer = new IntersectionObserver(entries => {
+            entries.forEach(entry => {
+                visibleMap.set(entry.target, entry.isIntersecting)
+            })
+            const anyVisible = Array.from(visibleMap.values()).some(Boolean)
+            setShowFloating(!anyVisible)
+        }, { threshold: 0.1 })
+
+        triggers.forEach(el => observer.observe(el))
+        return () => observer.disconnect()
+    }, [ isMobileMenuOpen ])
 
     return (
         <>
@@ -68,7 +90,7 @@ export default function Header () {
                             </button>
                             <button
                                 onClick={handleScheduleClick}
-                                className="academic-button px-6 py-2 text-sm font-semibold rounded-md flex items-center space-x-2"
+                                className="schedule-trigger academic-button px-6 py-2 text-sm font-semibold rounded-md flex items-center space-x-2"
                             >
                                 <Calendar className="w-4 h-4" />
                                 <span>Schedule Now</span>
@@ -107,7 +129,7 @@ export default function Header () {
                             </button>
                             <button
                                 onClick={handleScheduleClick}
-                                className="academic-button w-full px-4 py-2 text-sm font-semibold rounded-md flex items-center justify-center space-x-2"
+                                className="schedule-trigger academic-button w-full px-4 py-2 text-sm font-semibold rounded-md flex items-center justify-center space-x-2"
                             >
                                 <Calendar className="w-4 h-4" />
                                 <span>Schedule Now</span>
@@ -118,13 +140,15 @@ export default function Header () {
             </header>
 
             {/* Floating Schedule Button */}
-            <button
-                onClick={handleScheduleClick}
-                className="schedule-button academic-button px-4 py-3 rounded-full flex items-center justify-center space-x-2 animate-academic-glow"
-            >
-                <Calendar className="w-5 h-5" />
-                <span className="font-semibold">Schedule Now</span>
-            </button>
+            {showFloating && (
+                <button
+                    onClick={handleScheduleClick}
+                    className="schedule-button academic-button px-4 py-3 rounded-full flex items-center justify-center space-x-2 animate-academic-glow"
+                >
+                    <Calendar className="w-5 h-5" />
+                    <span className="font-semibold">Schedule Now</span>
+                </button>
+            )}
         </>
     )
 }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ArrowRight, Star, MapPin, GraduationCap } from 'lucide-react'
+import { useCal } from './CalProvider'
 
 // Academic Achievement SVG Icon
 const AcademicIcon = () => (
@@ -10,12 +11,7 @@ const AcademicIcon = () => (
 )
 
 export default function Hero () {
-    const scrollToContact = () => {
-        const element = document.getElementById('contact')
-        if (element) {
-            element.scrollIntoView({ behavior: 'smooth' })
-        }
-    }
+    const { open } = useCal()
 
     return (
         <section className="relative min-h-screen flex items-center justify-center overflow-hidden">
@@ -61,8 +57,8 @@ export default function Hero () {
                     {/* CTA Buttons */}
                     <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-12 animate-slide-up delay-400">
                         <button
-                            onClick={scrollToContact}
-                            className="academic-button px-8 py-4 text-lg font-semibold rounded-lg flex items-center space-x-2 w-full sm:w-auto"
+                            onClick={open}
+                            className="schedule-trigger academic-button px-8 py-4 text-lg font-semibold rounded-lg flex items-center space-x-2 w-full sm:w-auto"
                         >
                             <span>Schedule Free Consultation</span>
                             <ArrowRight className="w-5 h-5" />

--- a/src/components/Pricing.tsx
+++ b/src/components/Pricing.tsx
@@ -2,14 +2,11 @@
 
 import { Calendar } from 'lucide-react'
 import { siteContent } from '@/data/siteContent'
+import { useCal } from './CalProvider'
 
 export default function Pricing () {
     const { subheading, plans } = siteContent.pricing
-
-    const scrollToContact = () => {
-        const element = document.getElementById('contact')
-        if (element) element.scrollIntoView({ behavior: 'smooth' })
-    }
+    const { open } = useCal()
 
     return (
         <section id="pricing" className="py-20 lg:py-32 bg-academic-dark-blue">
@@ -28,10 +25,10 @@ export default function Pricing () {
                     {plans.map(plan => (
                         <div
                             key={plan.id}
-                            className={`academic-card p-8 text-center academic-hover relative ${plan.popular ? 'border-2 border-academic-gold' : ''}`}
+                            className={`academic-card p-8 text-center academic-hover relative flex flex-col ${plan.popular ? 'border-2 border-academic-gold' : ''}`}
                         >
                             {plan.popular && (
-                                <span className="absolute top-4 right-4 bg-academic-gold text-academic-navy text-xs font-semibold px-3 py-1 rounded-full">
+                                <span className="absolute top-4 right-4 border-2 border-academic-gold text-academic-gold text-xs font-semibold px-3 py-1 rounded-full bg-academic-navy">
                                     Most Popular
                                 </span>
                             )}
@@ -40,14 +37,17 @@ export default function Pricing () {
                                 ${plan.price}
                                 <span className="text-lg text-gray-300">{plan.unit}</span>
                             </div>
-                            <ul className="space-y-2 mb-6">
+                            <ul className="space-y-2 mb-6 flex-grow">
                                 {plan.features.map((feature, idx) => (
-                                    <li key={idx} className="text-gray-300 text-sm">{feature}</li>
+                                    <li key={idx} className="flex items-start text-gray-300 text-sm">
+                                        <div className="w-2 h-2 bg-academic-gold rounded-full mt-1 mr-2 flex-shrink-0"></div>
+                                        {feature}
+                                    </li>
                                 ))}
                             </ul>
                             <button
-                                onClick={scrollToContact}
-                                className="academic-button w-full px-4 py-3 font-semibold rounded-md flex items-center justify-center space-x-2"
+                                onClick={open}
+                                className="schedule-trigger academic-button w-full px-4 py-3 font-semibold rounded-md flex items-center justify-center space-x-2 mt-auto"
                             >
                                 <Calendar className="w-4 h-4" />
                                 <span>{plan.cta}</span>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -87,8 +87,8 @@ export default function Services () {
                             </p>
                             <ul className="space-y-2">
                                 {service.features.map((feature, idx) => (
-                                    <li key={idx} className="text-sm text-gray-400 flex items-center">
-                                        <div className="w-1.5 h-1.5 bg-academic-gold rounded-full mr-3"></div>
+                                    <li key={idx} className="text-sm text-gray-400 flex items-start">
+                                        <div className="w-2 h-2 bg-academic-gold rounded-full mt-1 mr-3 flex-shrink-0"></div>
                                         {feature}
                                     </li>
                                 ))}

--- a/src/components/ui/PricingCard.tsx
+++ b/src/components/ui/PricingCard.tsx
@@ -1,24 +1,22 @@
 import Button from './Button';
 import { PricingPlan } from "@/types";
+import { useCal } from '../CalProvider';
 
 interface PricingCardProps {
     plan: PricingPlan;
 }
 
 const PricingCard = ({ plan }: PricingCardProps) => {
+    const { open } = useCal();
     return (
-        <div className={`
-      bg-white rounded-lg shadow-lg overflow-hidden border
-      ${plan.popular ? 'border-yellow-500 transform scale-105 z-10' : 'border-gray-200'}
-      transition-all hover:shadow-xl
-    `}>
+        <div className={`bg-white rounded-lg shadow-lg overflow-hidden border flex flex-col ${plan.popular ? 'border-yellow-500 transform scale-105 z-10' : 'border-gray-200'} transition-all hover:shadow-xl`}>
             {plan.popular && (
                 <div className="bg-yellow-600 text-white text-center py-1 text-sm font-medium">
                     Most Popular
                 </div>
             )}
 
-            <div className="p-6">
+            <div className="p-6 flex flex-col flex-grow">
                 <h3 className="text-xl font-bold text-navy-800 mb-2">{plan.name}</h3>
 
                 <div className="flex items-baseline mb-6">
@@ -26,12 +24,10 @@ const PricingCard = ({ plan }: PricingCardProps) => {
                     <span className="text-gray-600 ml-1">{plan.unit}</span>
                 </div>
 
-                <ul className="space-y-3 mb-8">
+                <ul className="space-y-3 mb-8 flex-grow">
                     {plan.features.map((feature, index) => (
                         <li key={index} className="flex items-start">
-                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-yellow-600 mr-2 mt-0.5 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
-                                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-                            </svg>
+                            <div className="w-2 h-2 bg-yellow-600 rounded-full mt-1.5 mr-3 flex-shrink-0"></div>
                             <span className="text-gray-700">{feature}</span>
                         </li>
                     ))}
@@ -40,7 +36,8 @@ const PricingCard = ({ plan }: PricingCardProps) => {
                 <Button
                     variant={plan.popular ? 'primary' : 'outline'}
                     fullWidth
-                    href="#schedule"
+                    onClick={open}
+                    className="schedule-trigger"
                 >
                     {plan.cta}
                 </Button>


### PR DESCRIPTION
## Summary
- integrate Cal.com scheduling as a blurred popup modal with context provider
- highlight “Most Popular” pricing with a bordered tag and aligned CTA buttons
- normalize bullet styles and hide floating schedule button when another is visible

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6b54e510c832b9c8dcdd2d64cc19e