### PR TITLE
Enhance scheduling modal and pricing cards

### DIFF
--- a/src/components/CalModal.tsx
+++ b/src/components/CalModal.tsx
@@ -1,25 +1,28 @@
 'use client'
-import { X } from 'lucide-react'
+
+import Button from './ui/Button'
 
 interface CalModalProps {
+  url: string
   onClose: () => void
 }
 
-export default function CalModal({ onClose }: CalModalProps) {
+export default function CalModal ({ url, onClose }: CalModalProps) {
   return (
     <div className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/60 backdrop-blur-md p-4">
-      <div className="w-full max-w-3xl h-[80vh] bg-white rounded-lg overflow-hidden relative">
-        <button
+      <div className="w-full max-w-5xl h-[90vh] bg-white rounded-lg overflow-hidden relative">
+        <Button
           onClick={onClose}
-          className="absolute top-3 right-3 text-gray-600 hover:text-gray-800"
-          aria-label="Close schedule modal"
+          variant="secondary"
+          size="sm"
+          className="absolute top-4 right-4 z-10"
         >
-          <X className="w-6 h-6" />
-        </button>
+          Close
+        </Button>
         <iframe
-          src="https://cal.com/thebayarea/consultation?embed=1"
+          src={url}
           className="w-full h-full border-0"
-          title="Schedule consultation"
+          title="Schedule"
         />
       </div>
     </div>

--- a/src/components/CalProvider.tsx
+++ b/src/components/CalProvider.tsx
@@ -1,29 +1,34 @@
 'use client'
-import { createContext, useContext, useState, ReactNode, useEffect } from 'react'
+import { createContext, useContext, useState, ReactNode } from 'react'
 import CalModal from './CalModal'
 
 interface CalContextValue {
-  open: () => void
+  open: (url?: string) => void
   close: () => void
 }
 
 const CalContext = createContext<CalContextValue | undefined>(undefined)
+const defaultUrl = 'https://cal.com/thebayarea/consultation?embed=1'
 
-export function CalProvider({ children }: { children: ReactNode }) {
-  const [isOpen, setIsOpen] = useState(false)
+export function CalProvider ({ children }: { children: ReactNode }) {
+  const [ isOpen, setIsOpen ] = useState(false)
+  const [ url, setUrl ] = useState(defaultUrl)
 
-  const open = () => setIsOpen(true)
+  const open = (link: string = defaultUrl) => {
+    setUrl(link)
+    setIsOpen(true)
+  }
   const close = () => setIsOpen(false)
 
   return (
     <CalContext.Provider value={{ open, close }}>
       {children}
-      {isOpen && <CalModal onClose={close} />}
+      {isOpen && <CalModal url={url} onClose={close} />}
     </CalContext.Provider>
   )
 }
 
-export function useCal() {
+export function useCal () {
   const ctx = useContext(CalContext)
   if (!ctx) throw new Error('useCal must be used within CalProvider')
   return ctx

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -106,7 +106,7 @@ export default function Contact () {
                                 Ready to get started? Schedule a free consultation to discuss your goals.
                             </p>
                             <button
-                                onClick={open}
+                                onClick={() => open()}
                                 className="schedule-trigger academic-button px-6 py-4 text-lg font-semibold rounded-lg flex items-center justify-center space-x-2 mx-auto"
                             >
                                 <Calendar className="w-5 h-5" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,7 +15,7 @@ export default function Header () {
 
         window.addEventListener('scroll', handleScroll)
         return () => window.removeEventListener('scroll', handleScroll)
-    }, [ ])
+    }, [])
 
     const scrollToSection = (sectionId: string) => {
         const element = document.getElementById(sectionId)
@@ -48,7 +48,7 @@ export default function Header () {
 
         triggers.forEach(el => observer.observe(el))
         return () => observer.disconnect()
-    }, [ isMobileMenuOpen ])
+    }, [isMobileMenuOpen])
 
     return (
         <>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -57,7 +57,7 @@ export default function Hero () {
                     {/* CTA Buttons */}
                     <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-12 animate-slide-up delay-400">
                         <button
-                            onClick={open}
+                            onClick={() => open()}
                             className="schedule-trigger academic-button px-8 py-4 text-lg font-semibold rounded-lg flex items-center space-x-2 w-full sm:w-auto"
                         >
                             <span>Schedule Free Consultation</span>

--- a/src/components/Pricing.tsx
+++ b/src/components/Pricing.tsx
@@ -1,61 +1,25 @@
 'use client'
 
-import { Calendar } from 'lucide-react'
+import PricingCard from './ui/PricingCard'
 import { siteContent } from '@/data/siteContent'
-import { useCal } from './CalProvider'
 
 export default function Pricing () {
-    const { subheading, plans } = siteContent.pricing
-    const { open } = useCal()
-
-    return (
-        <section id="pricing" className="py-20 lg:py-32 bg-academic-dark-blue">
-            <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-                <div className="text-center mb-16">
-                    <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6 title-font">
-                        <span className="text-white">Investment in</span>
-                        <span className="block text-gradient">Your Child's Future</span>
-                    </h2>
-                    <p className="text-lg sm:text-xl text-gray-300 max-w-3xl mx-auto">
-                        {subheading}
-                    </p>
-                </div>
-
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-                    {plans.map(plan => (
-                        <div
-                            key={plan.id}
-                            className={`academic-card p-8 text-center academic-hover relative flex flex-col ${plan.popular ? 'border-2 border-academic-gold' : ''}`}
-                        >
-                            {plan.popular && (
-                                <span className="absolute top-4 right-4 border-2 border-academic-gold text-academic-gold text-xs font-semibold px-3 py-1 rounded-full bg-academic-navy">
-                                    Most Popular
-                                </span>
-                            )}
-                            <h3 className="text-xl font-bold text-white mb-4 title-font">{plan.name}</h3>
-                            <div className="text-4xl font-bold text-academic-gold mb-4">
-                                ${plan.price}
-                                <span className="text-lg text-gray-300">{plan.unit}</span>
-                            </div>
-                            <ul className="space-y-2 mb-6 flex-grow">
-                                {plan.features.map((feature, idx) => (
-                                    <li key={idx} className="flex items-start text-gray-300 text-sm">
-                                        <div className="w-2 h-2 bg-academic-gold rounded-full mt-1 mr-2 flex-shrink-0"></div>
-                                        {feature}
-                                    </li>
-                                ))}
-                            </ul>
-                            <button
-                                onClick={open}
-                                className="schedule-trigger academic-button w-full px-4 py-3 font-semibold rounded-md flex items-center justify-center space-x-2 mt-auto"
-                            >
-                                <Calendar className="w-4 h-4" />
-                                <span>{plan.cta}</span>
-                            </button>
-                        </div>
-                    ))}
-                </div>
-            </div>
-        </section>
-    )
+  const { heading, subheading, plans } = siteContent.pricing
+  return (
+    <section id="pricing" className="py-16 bg-white">
+      <div className="container mx-auto px-4">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl md:text-4xl font-bold text-navy-800 mb-3">
+            {heading}
+          </h2>
+          <p className="text-xl text-navy-600 max-w-3xl mx-auto">{subheading}</p>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-5xl mx-auto">
+          {plans.map((plan) => (
+            <PricingCard key={plan.id} plan={plan} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
 }

--- a/src/components/ui/PricingCard.tsx
+++ b/src/components/ui/PricingCard.tsx
@@ -36,7 +36,7 @@ const PricingCard = ({ plan }: PricingCardProps) => {
                 <Button
                     variant={plan.popular ? 'primary' : 'outline'}
                     fullWidth
-                    onClick={open}
+                    onClick={() => open('https://cal.com/thebayarea/1-hour-session?embed=1')}
                     className="schedule-trigger"
                 >
                     {plan.cta}


### PR DESCRIPTION
## Summary
- Expand Cal.com scheduling modal to nearly full-screen and add a styled close button for better usability.
- Support dynamic Cal.com URLs in the provider, enabling both consultation and 1-hour session scheduling.
- Rework pricing section with highlighted "Most Popular" card and session booking buttons.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6ca4b4e98832b81e4a0a2ee0ea2aa