### PR TITLE
Add light/dark mode toggle

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -49,7 +49,7 @@ export default function RootLayout ({
     children: React.ReactNode
 }) {
     return (
-        <html lang="en" className="scroll-smooth">
+        <html lang="en" className="scroll-smooth" suppressHydrationWarning>
         <head>
             <link rel="preconnect" href="https://fonts.googleapis.com" />
             <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
@@ -80,7 +80,7 @@ export default function RootLayout ({
                 }}
             />
         </head>
-        <body className="bg-academic-navy text-white antialiased">
+        <body className="bg-white text-academic-navy dark:bg-academic-navy dark:text-white antialiased">
         <CalProvider>
             {children}
         </CalProvider>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { Menu, X, Calendar } from 'lucide-react'
 import { useCal } from './CalProvider'
+import ThemeToggle from './ThemeToggle'
 
 export default function Header () {
     const [ isScrolled, setIsScrolled ] = useState(false)
@@ -72,22 +73,23 @@ export default function Header () {
                         <div className="hidden lg:flex items-center space-x-8">
                             <button
                                 onClick={() => scrollToSection('services')}
-                                className="text-white hover:text-academic-gold transition-colors font-medium"
+                                className="text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium"
                             >
                                 Services
                             </button>
                             <button
                                 onClick={() => scrollToSection('about')}
-                                className="text-white hover:text-academic-gold transition-colors font-medium"
+                                className="text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium"
                             >
                                 About
                             </button>
                             <button
                                 onClick={() => scrollToSection('faq')}
-                                className="text-white hover:text-academic-gold transition-colors font-medium"
+                                className="text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium"
                             >
                                 FAQ
                             </button>
+                            <ThemeToggle />
                             <button
                                 onClick={handleScheduleClick}
                                 className="schedule-trigger academic-button px-6 py-2 text-sm font-semibold rounded-md flex items-center space-x-2"
@@ -98,32 +100,35 @@ export default function Header () {
                         </div>
 
                         {/* Mobile Menu Button */}
-                        <button
-                            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-                            className="lg:hidden text-white p-2"
-                        >
-                            {isMobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
-                        </button>
+                        <div className="flex items-center space-x-2">
+                            <ThemeToggle />
+                            <button
+                                onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                                className="lg:hidden text-academic-navy dark:text-white p-2"
+                            >
+                                {isMobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+                            </button>
+                        </div>
                     </div>
 
                     {/* Mobile Navigation */}
                     {isMobileMenuOpen && (
-                        <div className="lg:hidden bg-academic-dark-blue/95 backdrop-blur-md rounded-lg mt-2 p-4 space-y-4">
+                        <div className="lg:hidden bg-white dark:bg-academic-dark-blue/95 backdrop-blur-md rounded-lg mt-2 p-4 space-y-4">
                             <button
                                 onClick={() => scrollToSection('services')}
-                                className="block w-full text-left text-white hover:text-academic-gold transition-colors font-medium py-2"
+                                className="block w-full text-left text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium py-2"
                             >
                                 Services
                             </button>
                             <button
                                 onClick={() => scrollToSection('about')}
-                                className="block w-full text-left text-white hover:text-academic-gold transition-colors font-medium py-2"
+                                className="block w-full text-left text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium py-2"
                             >
                                 About
                             </button>
                             <button
                                 onClick={() => scrollToSection('faq')}
-                                className="block w-full text-left text-white hover:text-academic-gold transition-colors font-medium py-2"
+                                className="block w-full text-left text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium py-2"
                             >
                                 FAQ
                             </button>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Sun, Moon } from 'lucide-react'
+
+export default function ThemeToggle () {
+    const [ theme, setTheme ] = useState<'light' | 'dark'>('light')
+    const [ mounted, setMounted ] = useState(false)
+
+    useEffect(() => {
+        const stored = localStorage.getItem('theme')
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+        const initial = stored === 'dark' || (!stored && prefersDark) ? 'dark' : 'light'
+        setTheme(initial)
+        document.documentElement.classList.toggle('dark', initial === 'dark')
+        setMounted(true)
+    }, [])
+
+    const toggleTheme = () => {
+        const next = theme === 'light' ? 'dark' : 'light'
+        setTheme(next)
+        document.documentElement.classList.toggle('dark', next === 'dark')
+        localStorage.setItem('theme', next)
+    }
+
+    if (!mounted) return null
+
+    return (
+        <button
+            onClick={toggleTheme}
+            aria-label="Toggle dark mode"
+            className="p-2 rounded-md text-academic-navy dark:text-white hover:bg-academic-light-blue/20 dark:hover:bg-academic-light-blue/40 transition-colors"
+        >
+            {theme === 'light' ? <Moon className="w-5 h-5" /> : <Sun className="w-5 h-5" />}
+        </button>
+    )
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+    darkMode: 'class',
     content: [
         './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
         './src/components/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
## Summary
- enable Tailwind class-based dark mode
- add theme toggle component and integrate into header
- apply theme-aware colors for body and navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Object literal may only specify known properties, and 'note' does not exist in type)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d0483368832ba6172875eb1d33f5