### PR TITLE
Showcase local school logos in hero section

### DIFF
--- a/public/logos/acalanes.svg
+++ b/public/logos/acalanes.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 40">
+  <metadata>{"school":"Acalanes High School","phone":"925-280-3970"}</metadata>
+  <rect width="100" height="40" fill="#003DA5"/>
+  <text x="50" y="25" font-size="18" text-anchor="middle" fill="white">AHS</text>
+</svg>

--- a/public/logos/campolindo.svg
+++ b/public/logos/campolindo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 40">
+  <metadata>{"school":"Campolindo High School","phone":"925-280-3950"}</metadata>
+  <rect width="100" height="40" fill="#990000"/>
+  <text x="50" y="25" font-size="18" text-anchor="middle" fill="white">CHS</text>
+</svg>

--- a/public/logos/laslomas.svg
+++ b/public/logos/laslomas.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 40">
+  <metadata>{"school":"Las Lomas High School","phone":"925-280-3920"}</metadata>
+  <rect width="100" height="40" fill="#A65100"/>
+  <text x="50" y="25" font-size="18" text-anchor="middle" fill="white">LLHS</text>
+</svg>

--- a/public/logos/miramonte.svg
+++ b/public/logos/miramonte.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 40">
+  <metadata>{"school":"Miramonte High School","phone":"925-280-3930"}</metadata>
+  <rect width="100" height="40" fill="#00693E"/>
+  <text x="50" y="25" font-size="18" text-anchor="middle" fill="white">MHS</text>
+</svg>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ArrowRight, Star, MapPin, GraduationCap } from 'lucide-react'
+import Image from 'next/image'
 import { useCal } from './CalProvider'
 
 // Academic Achievement SVG Icon
@@ -74,23 +75,48 @@ export default function Hero () {
                         </button>
                     </div>
 
-                    {/* Key Stats */}
-                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 max-w-3xl mx-auto animate-slide-up delay-500">
-                        <div className="text-center">
-                            <div className="text-2xl sm:text-3xl font-bold text-academic-gold mb-1 title-font">15+</div>
-                            <div className="text-sm text-gray-400">Years Experience</div>
-                        </div>
-                        <div className="text-center">
-                            <div className="text-2xl sm:text-3xl font-bold text-academic-gold mb-1 title-font">All</div>
-                            <div className="text-sm text-gray-400">Test Types</div>
-                        </div>
-                        <div className="text-center">
-                            <div className="text-2xl sm:text-3xl font-bold text-academic-gold mb-1 title-font">Local</div>
-                            <div className="text-sm text-gray-400">Schools Known</div>
-                        </div>
-                        <div className="text-center">
-                            <div className="text-2xl sm:text-3xl font-bold text-academic-gold mb-1 title-font">Care</div>
-                            <div className="text-sm text-gray-400">& Attention</div>
+                    {/* School Logos */}
+                    <div className="mt-12 animate-slide-up delay-500">
+                        <p className="text-sm text-gray-400 mb-4">
+                            Trusted by families from these East Bay schools:
+                        </p>
+                        <div className="flex flex-wrap items-center justify-center gap-8 opacity-80">
+                            <Image
+                                src="/logos/acalanes.svg"
+                                alt="Acalanes High School logo"
+                                className="h-12 w-auto"
+                                width={120}
+                                height={48}
+                                data-name="Acalanes High School"
+                                data-phone="925-280-3970"
+                            />
+                            <Image
+                                src="/logos/campolindo.svg"
+                                alt="Campolindo High School logo"
+                                className="h-12 w-auto"
+                                width={120}
+                                height={48}
+                                data-name="Campolindo High School"
+                                data-phone="925-280-3950"
+                            />
+                            <Image
+                                src="/logos/laslomas.svg"
+                                alt="Las Lomas High School logo"
+                                className="h-12 w-auto"
+                                width={120}
+                                height={48}
+                                data-name="Las Lomas High School"
+                                data-phone="925-280-3920"
+                            />
+                            <Image
+                                src="/logos/miramonte.svg"
+                                alt="Miramonte High School logo"
+                                className="h-12 w-auto"
+                                width={120}
+                                height={48}
+                                data-name="Miramonte High School"
+                                data-phone="925-280-3930"
+                            />
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Replace hero stats with startup-style wall showcasing East Bay school logos
- Add metadata-rich SVG logos for Acalanes, Campolindo, Las Lomas, and Miramonte High Schools

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Object literal may only specify known properties, and 'note' does not exist in type)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d14e7cb4832ba3b4bfded7335ae2