### PR TITLE
feat: add theme toggle and ensure full light/dark theme support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "^14.2.32",
+        "next-themes": "^0.3.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sharp": "^0.33.2"
@@ -5085,6 +5086,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.3.0.tgz",
+      "integrity": "sha512-/QHIrsYpd6Kfk7xakK4svpDI5mmXP0gfvCoJdGpZQ2TOrQZmsW0QxjaiLn8wbIKjtm4BTSqLoix4lxYYOnLJ/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18",
+        "react-dom": "^16.8 || ^17 || ^18"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "next": "^14.2.32",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "sharp": "^0.33.2"
+    "sharp": "^0.33.2",
+    "next-themes": "^0.3.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.8.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,7 +15,26 @@
     --academic-gold: #D4AF37;
     --academic-light-gold: #E6C757;
     --academic-dark-gold: #B8941F;
-    --academic-off-white: #F8F9FA;
+    --academic-off-white: #F5F1E6;
+    --background: var(--academic-off-white);
+    --foreground: var(--academic-navy);
+    --title: var(--academic-dark-blue);
+    --muted: var(--academic-light-blue);
+    --card-bg: rgba(255, 255, 255, 0.9);
+    --card-border: rgba(11, 20, 38, 0.1);
+    --card-hover-bg: rgba(255, 255, 255, 1);
+    --card-hover-border: rgba(11, 20, 38, 0.3);
+}
+
+.dark {
+    --background: var(--academic-navy);
+    --foreground: var(--academic-off-white);
+    --title: var(--academic-off-white);
+    --muted: #A3B8CC;
+    --card-bg: rgba(11, 20, 38, 0.9);
+    --card-border: rgba(248, 249, 250, 0.1);
+    --card-hover-bg: rgba(11, 20, 38, 1);
+    --card-hover-border: rgba(248, 249, 250, 0.3);
 }
 
 * {
@@ -29,8 +48,8 @@ html {
 }
 
 body {
-    color: var(--academic-navy);
-    background: var(--academic-off-white);
+    color: var(--foreground);
+    background: var(--background);
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
     line-height: 1.6;
     -webkit-font-smoothing: antialiased;
@@ -96,16 +115,16 @@ body {
 }
 
 .academic-card {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--card-bg);
     border-radius: 12px;
     backdrop-filter: blur(10px);
-    border: 1px solid rgba(11, 20, 38, 0.1);
+    border: 1px solid var(--card-border);
     transition: all 0.3s ease;
 }
 
 .academic-card:hover {
-    background: rgba(255, 255, 255, 1);
-    border-color: rgba(11, 20, 38, 0.3);
+    background: var(--card-hover-bg);
+    border-color: var(--card-hover-border);
     transform: translateY(-4px);
     box-shadow: 0 12px 35px rgba(0, 0, 0, 0.1);
 }
@@ -119,6 +138,7 @@ body {
 
 .title-font {
     font-family: 'Playfair Display', serif;
+    color: var(--title);
 }
 
 .logo-font {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import './globals.css'
 import { CalProvider } from '@/components/CalProvider'
+import { ThemeProvider } from 'next-themes'
 
 export const metadata: Metadata = {
     title: 'Bay Area Academic Tutoring | SAT, ACT & School Support | Expert Private Tutor',
@@ -49,7 +50,7 @@ export default function RootLayout ({
     children: React.ReactNode
 }) {
     return (
-        <html lang="en" className="scroll-smooth">
+        <html lang="en" className="scroll-smooth" suppressHydrationWarning>
         <head>
             <link rel="preconnect" href="https://fonts.googleapis.com" />
             <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
@@ -80,10 +81,12 @@ export default function RootLayout ({
                 }}
             />
         </head>
-        <body className="bg-academic-navy text-white antialiased">
-        <CalProvider>
-            {children}
-        </CalProvider>
+        <body className="antialiased bg-background text-foreground">
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+            <CalProvider>
+                {children}
+            </CalProvider>
+        </ThemeProvider>
         </body>
         </html>
     )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import Footer from '@/components/Footer'
 
 export default function HomePage () {
     return (
-        <div className="min-h-screen bg-academic-navy">
+        <div className="min-h-screen bg-background text-foreground">
             <Header />
             <main>
                 <Hero />

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -37,15 +37,15 @@ export default function About () {
     ]
 
     return (
-        <section id="about" className="py-20 lg:py-32 bg-academic-navy">
+        <section id="about" className="py-20 lg:py-32 bg-background dark:bg-academic-navy">
             <div className="container mx-auto px-4 sm:px-6 lg:px-8">
                 <div className="max-w-6xl mx-auto">
                     <div className="text-center mb-16">
                         <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6 title-font">
-                            <span className="text-white">About Your</span>
-                            <span className="block text-gradient">Dedicated Tutor</span>
+                            <span className="text-foreground dark:text-white">About Your</span>
+                            <span className="block text-academic-gold dark:text-gradient">Dedicated Tutor</span>
                         </h2>
-                        <p className="text-lg sm:text-xl text-gray-300 max-w-3xl mx-auto">
+                        <p className="text-lg sm:text-xl text-academic-medium-blue dark:text-academic-off-white max-w-3xl mx-auto">
                             You deserve a tutor who understands both the material and the local academic environment.
                             I combine UC Berkeley education with deep Bay Area teaching experience.
                         </p>
@@ -57,21 +57,21 @@ export default function About () {
                             <div className="academic-card p-8">
                                 <div className="flex items-center mb-6">
                                     <TeachingIcon />
-                                    <h3 className="text-2xl font-bold text-white ml-4 title-font">My Teaching Approach</h3>
+                                    <h3 className="text-2xl font-bold text-foreground dark:text-white ml-4 title-font">My Teaching Approach</h3>
                                 </div>
-                                <p className="text-gray-300 leading-relaxed mb-6">
+                                <p className="text-academic-medium-blue dark:text-academic-off-white leading-relaxed mb-6">
                                     You get more than just test prep. I work as your private tutor and academic coach,
                                     providing support that directly connects to your classroom experience.
                                     I've worked at tutoring centers and as a private tutor throughout the Bay Area.
                                 </p>
-                                <p className="text-gray-300 leading-relaxed">
+                                <p className="text-academic-medium-blue dark:text-academic-off-white leading-relaxed">
                                     Your success comes from understanding concepts deeply and building confidence.
                                     I create personalized strategies that work with your learning style and academic goals.
                                 </p>
                             </div>
 
                             <div className="academic-card p-8">
-                                <h3 className="text-xl font-bold text-white mb-4 flex items-center title-font">
+                                <h3 className="text-xl font-bold text-foreground dark:text-white mb-4 flex items-center title-font">
                                     <Award className="w-6 h-6 text-academic-gold mr-3" />
                                     Areas of Expertise
                                 </h3>
@@ -79,7 +79,7 @@ export default function About () {
                                     {expertise.map((area, index) => (
                                         <div key={index} className="flex items-start">
                                             <div className="w-2 h-2 bg-academic-gold rounded-full mt-2 mr-3 flex-shrink-0"></div>
-                                            <span className="text-gray-300 text-sm">{area}</span>
+                                            <span className="text-academic-medium-blue dark:text-academic-off-white text-sm">{area}</span>
                                         </div>
                                     ))}
                                 </div>
@@ -94,10 +94,10 @@ export default function About () {
                                         <div className="text-academic-gold mb-4 flex justify-center">
                                             {achievement.icon}
                                         </div>
-                                        <div className="text-2xl lg:text-3xl font-bold text-white mb-2 title-font">
+                                        <div className="text-2xl lg:text-3xl font-bold text-foreground dark:text-white mb-2 title-font">
                                             {achievement.stat}
                                         </div>
-                                        <div className="text-sm text-gray-400">
+                                        <div className="text-sm text-academic-medium-blue dark:text-academic-off-white">
                                             {achievement.label}
                                         </div>
                                     </div>
@@ -105,7 +105,7 @@ export default function About () {
                             </div>
 
                             <div className="academic-card p-8">
-                                <h3 className="text-xl font-bold text-white mb-6 flex items-center title-font">
+                                <h3 className="text-xl font-bold text-foreground dark:text-white mb-6 flex items-center title-font">
                                     <MapPin className="w-6 h-6 text-academic-gold mr-3" />
                                     Bay Area Advantage
                                 </h3>
@@ -113,7 +113,7 @@ export default function About () {
                                     {bayAreaExperience.map((point, index) => (
                                         <div key={index} className="flex items-start">
                                             <div className="w-2 h-2 bg-academic-gold rounded-full mt-2 mr-3 flex-shrink-0"></div>
-                                            <div className="text-gray-300 text-sm">{point}</div>
+                                            <div className="text-academic-medium-blue dark:text-academic-off-white text-sm">{point}</div>
                                         </div>
                                     ))}
                                 </div>
@@ -122,18 +122,18 @@ export default function About () {
                     </div>
 
                     {/* Experience Section */}
-                    <div className="bg-academic-medium-blue/50 backdrop-blur-sm rounded-2xl p-8 lg:p-12 mb-16">
+                    <div className="bg-blue-100 dark:bg-academic-medium-blue/50 backdrop-blur-sm rounded-2xl p-8 lg:p-12 mb-16">
                         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
                             <div>
-                                <h3 className="text-2xl lg:text-3xl font-bold text-white mb-6 title-font flex items-center">
+                                <h3 className="text-2xl lg:text-3xl font-bold text-foreground dark:text-white mb-6 title-font flex items-center">
                                     <ExperienceIcon />
                                     <span className="ml-4">Professional Experience</span>
                                 </h3>
-                                <p className="text-gray-300 leading-relaxed mb-6">
+                                <p className="text-academic-medium-blue dark:text-academic-off-white leading-relaxed mb-6">
                                     I've worked as a private tutor and at established tutoring locations throughout the Bay Area.
                                     This experience gives me deep insight into local academic standards and teaching methods.
                                 </p>
-                                <p className="text-gray-300 leading-relaxed">
+                                <p className="text-academic-medium-blue dark:text-academic-off-white leading-relaxed">
                                     You benefit from my familiarity with Bay Area high schools, teachers, and curricula.
                                     I know what works and what doesn't in this specific academic environment.
                                 </p>
@@ -142,22 +142,22 @@ export default function About () {
                                 <div className="flex items-start space-x-4">
                                     <div className="w-2 h-2 bg-academic-gold rounded-full mt-1 flex-shrink-0"></div>
                                     <div>
-                                        <div className="text-white font-semibold mb-1">Private Tutoring</div>
-                                        <div className="text-gray-400 text-sm">One-on-one academic support in homes and libraries</div>
+                                        <div className="text-foreground dark:text-white font-semibold mb-1">Private Tutoring</div>
+                                        <div className="text-academic-medium-blue dark:text-academic-off-white text-sm">One-on-one academic support in homes and libraries</div>
                                     </div>
                                 </div>
                                 <div className="flex items-start space-x-4">
                                     <div className="w-2 h-2 bg-academic-gold rounded-full mt-1 flex-shrink-0"></div>
                                     <div>
-                                        <div className="text-white font-semibold mb-1">Tutoring Centers</div>
-                                        <div className="text-gray-400 text-sm">Professional tutoring experience at established locations</div>
+                                        <div className="text-foreground dark:text-white font-semibold mb-1">Tutoring Centers</div>
+                                        <div className="text-academic-medium-blue dark:text-academic-off-white text-sm">Professional tutoring experience at established locations</div>
                                     </div>
                                 </div>
                                 <div className="flex items-start space-x-4">
                                     <div className="w-2 h-2 bg-academic-gold rounded-full mt-1 flex-shrink-0"></div>
                                     <div>
-                                        <div className="text-white font-semibold mb-1">Curriculum Expertise</div>
-                                        <div className="text-gray-400 text-sm">Deep knowledge of Bay Area school programs and standards</div>
+                                        <div className="text-foreground dark:text-white font-semibold mb-1">Curriculum Expertise</div>
+                                        <div className="text-academic-medium-blue dark:text-academic-off-white text-sm">Deep knowledge of Bay Area school programs and standards</div>
                                     </div>
                                 </div>
                             </div>
@@ -167,8 +167,8 @@ export default function About () {
                     {/* Call to action */}
                     <div className="text-center">
                         <div className="inline-block academic-card p-8 max-w-2xl">
-                            <h3 className="text-2xl font-bold text-white mb-4 title-font">Ready to Excel Academically?</h3>
-                            <p className="text-gray-300 mb-6">
+                            <h3 className="text-2xl font-bold text-foreground dark:text-white mb-4 title-font">Ready to Excel Academically?</h3>
+                            <p className="text-academic-medium-blue dark:text-academic-off-white mb-6">
                                 You get the best tutoring support in the Bay Area. Let's discuss your goals and create a plan for your academic success.
                             </p>
                             <button

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -14,7 +14,7 @@ export default function Contact () {
     const { open } = useCal()
 
     return (
-        <section id="contact" className="py-20 lg:py-32 bg-academic-navy">
+        <section id="contact" className="py-20 lg:py-32 bg-background dark:bg-academic-navy">
             <div className="container mx-auto px-4 sm:px-6 lg:px-8">
                 <div className="max-w-6xl mx-auto">
                     <div className="text-center mb-16">
@@ -22,10 +22,10 @@ export default function Contact () {
                             <ContactIcon />
                         </div>
                         <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6 title-font">
-                            <span className="text-white">Schedule Your</span>
-                            <span className="block text-gradient">Academic Success</span>
+                            <span className="text-foreground dark:text-white">Schedule Your</span>
+                            <span className="block text-academic-gold dark:text-gradient">Academic Success</span>
                         </h2>
-                        <p className="text-lg sm:text-xl text-gray-300 max-w-3xl mx-auto">
+                        <p className="text-lg sm:text-xl text-academic-medium-blue dark:text-academic-off-white max-w-3xl mx-auto">
                             Take the first step toward academic excellence. Contact me to discuss your goals and start your journey to better grades and test scores.
                         </p>
                     </div>
@@ -34,66 +34,66 @@ export default function Contact () {
                         {/* Contact Information */}
                         <div className="space-y-8">
                             <div className="academic-card p-8">
-                                <h3 className="text-2xl font-bold text-white mb-6 title-font">Contact Information</h3>
+                                <h3 className="text-2xl font-bold text-foreground dark:text-white mb-6 title-font">Contact Information</h3>
 
                                 <div className="space-y-6">
                                     <div className="flex items-start space-x-4">
                                         <Phone className="w-6 h-6 text-academic-gold mt-1 flex-shrink-0" />
                                         <div>
-                                            <div className="text-white font-semibold mb-1">Phone</div>
-                                            <div className="text-gray-300">(925) 237-1327</div>
-                                            <div className="text-sm text-gray-400 mt-1">Call or text for quick responses</div>
+                                            <div className="text-foreground dark:text-white font-semibold mb-1">Phone</div>
+                                            <div className="text-academic-medium-blue dark:text-academic-off-white">(925) 237-1327</div>
+                                            <div className="text-sm text-academic-medium-blue dark:text-academic-off-white mt-1">Call or text for quick responses</div>
                                         </div>
                                     </div>
 
                                     <div className="flex items-start space-x-4">
                                         <Mail className="w-6 h-6 text-academic-gold mt-1 flex-shrink-0" />
                                         <div>
-                                            <div className="text-white font-semibold mb-1">Email</div>
-                                            <div className="text-gray-300">tutor@thebayareatutor.com</div>
-                                            <div className="text-sm text-gray-400 mt-1">I respond within 24 hours</div>
+                                            <div className="text-foreground dark:text-white font-semibold mb-1">Email</div>
+                                            <div className="text-academic-medium-blue dark:text-academic-off-white">tutor@thebayareatutor.com</div>
+                                            <div className="text-sm text-academic-medium-blue dark:text-academic-off-white mt-1">I respond within 24 hours</div>
                                         </div>
                                     </div>
 
                                     <div className="flex items-start space-x-4">
                                         <Clock className="w-6 h-6 text-academic-gold mt-1 flex-shrink-0" />
                                         <div>
-                                            <div className="text-white font-semibold mb-1">Availability</div>
-                                            <div className="text-gray-300">Flexible scheduling</div>
-                                            <div className="text-sm text-gray-400 mt-1">Evenings, weekends, and online sessions</div>
+                                            <div className="text-foreground dark:text-white font-semibold mb-1">Availability</div>
+                                            <div className="text-academic-medium-blue dark:text-academic-off-white">Flexible scheduling</div>
+                                            <div className="text-sm text-academic-medium-blue dark:text-academic-off-white mt-1">Evenings, weekends, and online sessions</div>
                                         </div>
                                     </div>
                                 </div>
                             </div>
 
                             <div className="academic-card p-8">
-                                <h3 className="text-xl font-bold text-white mb-4 flex items-center title-font">
+                                <h3 className="text-xl font-bold text-foreground dark:text-white mb-4 flex items-center title-font">
                                     <User className="w-6 h-6 text-academic-gold mr-3" />
                                     What You Get
                                 </h3>
                                 <div className="space-y-4">
                                     <div className="flex items-start">
                                         <div className="w-2 h-2 bg-academic-gold rounded-full mt-2 mr-3 flex-shrink-0"></div>
-                                        <div className="text-gray-300 text-sm">
-                                            <span className="text-white font-medium">Free 30-minute consultation</span> to discuss your goals and challenges
+                                        <div className="text-academic-medium-blue dark:text-academic-off-white text-sm">
+                                            <span className="text-foreground dark:text-white font-medium">Free 30-minute consultation</span> to discuss your goals and challenges
                                         </div>
                                     </div>
                                     <div className="flex items-start">
                                         <div className="w-2 h-2 bg-academic-gold rounded-full mt-2 mr-3 flex-shrink-0"></div>
-                                        <div className="text-gray-300 text-sm">
-                                            <span className="text-white font-medium">Personalized learning plan</span> that works with your school curriculum
+                                        <div className="text-academic-medium-blue dark:text-academic-off-white text-sm">
+                                            <span className="text-foreground dark:text-white font-medium">Personalized learning plan</span> that works with your school curriculum
                                         </div>
                                     </div>
                                     <div className="flex items-start">
                                         <div className="w-2 h-2 bg-academic-gold rounded-full mt-2 mr-3 flex-shrink-0"></div>
-                                        <div className="text-gray-300 text-sm">
-                                            <span className="text-white font-medium">Flexible scheduling</span> for your busy lifestyle
+                                        <div className="text-academic-medium-blue dark:text-academic-off-white text-sm">
+                                            <span className="text-foreground dark:text-white font-medium">Flexible scheduling</span> for your busy lifestyle
                                         </div>
                                     </div>
                                     <div className="flex items-start">
                                         <div className="w-2 h-2 bg-academic-gold rounded-full mt-2 mr-3 flex-shrink-0"></div>
-                                        <div className="text-gray-300 text-sm">
-                                            <span className="text-white font-medium">Ongoing support</span> between sessions via email
+                                        <div className="text-academic-medium-blue dark:text-academic-off-white text-sm">
+                                            <span className="text-foreground dark:text-white font-medium">Ongoing support</span> between sessions via email
                                         </div>
                                     </div>
                                 </div>
@@ -102,7 +102,7 @@ export default function Contact () {
 
                         {/* Scheduling Section */}
                         <div className="academic-card p-8 flex flex-col justify-center text-center">
-                            <p className="text-gray-300 mb-6">
+                            <p className="text-academic-medium-blue dark:text-academic-off-white mb-6">
                                 Ready to get started? Schedule a free consultation to discuss your goals.
                             </p>
                             <button

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -30,7 +30,7 @@ export default function FAQ () {
     }))
 
     return (
-        <section id="faq" className="py-20 lg:py-32 bg-academic-dark-blue">
+        <section id="faq" className="py-20 lg:py-32 bg-background dark:bg-academic-dark-blue">
             <div className="container mx-auto px-4 sm:px-6 lg:px-8">
                 <div className="max-w-4xl mx-auto">
                     <div className="text-center mb-16">
@@ -38,10 +38,10 @@ export default function FAQ () {
                             <FAQIcon />
                         </div>
                         <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6 title-font">
-                            <span className="text-white">Frequently Asked</span>
-                            <span className="block text-gradient">Questions</span>
+                            <span className="text-foreground dark:text-white">Frequently Asked</span>
+                            <span className="block text-academic-gold dark:text-gradient">Questions</span>
                         </h2>
-                        <p className="text-lg sm:text-xl text-gray-300 max-w-2xl mx-auto">
+                        <p className="text-lg sm:text-xl text-academic-medium-blue dark:text-academic-off-white max-w-2xl mx-auto">
                             Get answers to common questions about my tutoring services and approach
                         </p>
                     </div>
@@ -53,7 +53,7 @@ export default function FAQ () {
                                     onClick={() => toggleItem(index)}
                                     className="w-full p-6 text-left flex items-center justify-between focus:outline-none"
                                 >
-                                    <h3 className="text-lg font-semibold text-white pr-4 title-font">
+                                    <h3 className="text-lg font-semibold text-foreground dark:text-white pr-4 title-font">
                                         {faq.question}
                                     </h3>
                                     <div className="text-academic-gold flex-shrink-0">
@@ -67,7 +67,7 @@ export default function FAQ () {
 
                                 <div className={`faq-content ${openItem === index ? 'open' : ''}`}>
                                     <div className="px-6 pb-6">
-                                        <p className="text-gray-300 leading-relaxed">
+                                        <p className="text-academic-medium-blue dark:text-academic-off-white leading-relaxed">
                                             {faq.answer}
                                         </p>
                                     </div>
@@ -78,8 +78,8 @@ export default function FAQ () {
 
                     <div className="mt-12 text-center">
                         <div className="inline-block academic-card p-6">
-                            <h3 className="text-xl font-bold text-white mb-3 title-font">Still have questions?</h3>
-                            <p className="text-gray-300 mb-4">
+                            <h3 className="text-xl font-bold text-foreground dark:text-white mb-3 title-font">Still have questions?</h3>
+                            <p className="text-academic-medium-blue dark:text-academic-off-white mb-4">
                                 Contact me directly to discuss your specific needs and goals
                             </p>
                             <button

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -15,7 +15,7 @@ export default function Footer () {
     }
 
     return (
-        <footer className="bg-academic-navy border-t border-academic-medium-blue/30">
+        <footer className="bg-academic-off-white dark:bg-academic-navy border-t border-academic-medium-blue/30 text-academic-navy dark:text-white">
             <div className="container mx-auto px-4 sm:px-6 lg:px-8">
                 {/* Main Footer Content */}
                 <div className="py-16 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
@@ -25,38 +25,38 @@ export default function Footer () {
                             <GraduationCap className="w-8 h-8 text-academic-gold" />
                             <h3 className="text-2xl font-bold text-academic-gold title-font">Bay Area Academic Tutor</h3>
                         </div>
-                        <p className="text-gray-300 leading-relaxed max-w-md">
+                        <p className="text-academic-medium-blue dark:text-academic-off-white leading-relaxed max-w-md">
                             Expert academic tutoring for SAT, ACT, SAT Subject Tests, and comprehensive school support.
                             UC Berkeley graduate with deep Bay Area experience and curriculum knowledge.
                         </p>
                         <div className="space-y-3">
                             <div className="flex items-center space-x-3">
                                 <Phone className="w-5 h-5 text-academic-gold" />
-                                <a href="tel:(925)237-1327" className="text-white hover:text-academic-gold transition-colors font-medium">
+                <a href="tel:(925)237-1327" className="hover:text-academic-gold transition-colors font-medium">
                                     (925) 237-1327
                                 </a>
                             </div>
                             <div className="flex items-center space-x-3">
                                 <Mail className="w-5 h-5 text-academic-gold" />
-                                <a href="mailto:tutor@thebayareatutor.com" className="text-white hover:text-academic-gold transition-colors font-medium">
+                                <a href="mailto:tutor@thebayareatutor.com" className="hover:text-academic-gold transition-colors font-medium">
                                     tutor@thebayareatutor.com
                                 </a>
                             </div>
                             <div className="flex items-center space-x-3">
                                 <MapPin className="w-5 h-5 text-academic-gold" />
-                                <span className="text-white font-medium">Bay Area • In-Person* & Online</span>
+                                <span className="font-medium">Bay Area • In-Person* & Online</span>
                             </div>
                         </div>
                     </div>
 
                     {/* Services */}
                     <div>
-                        <h4 className="text-lg font-semibold text-white mb-6 title-font">Tutoring Services</h4>
+                        <h4 className="text-lg font-semibold mb-6 title-font">Tutoring Services</h4>
                         <ul className="space-y-3">
                             <li>
                                 <button
                                     onClick={() => scrollToSection('services')}
-                                    className="text-gray-400 hover:text-academic-gold transition-colors text-sm"
+                                    className="text-academic-medium-blue dark:text-academic-off-white hover:text-academic-gold transition-colors text-sm"
                                 >
                                     Test Preparation
                                 </button>
@@ -64,7 +64,7 @@ export default function Footer () {
                             <li>
                                 <button
                                     onClick={() => scrollToSection('services')}
-                                    className="text-gray-400 hover:text-academic-gold transition-colors text-sm"
+                                    className="text-academic-medium-blue dark:text-academic-off-white hover:text-academic-gold transition-colors text-sm"
                                 >
                                     Academic Support
                                 </button>
@@ -72,7 +72,7 @@ export default function Footer () {
                             <li>
                                 <button
                                     onClick={() => scrollToSection('services')}
-                                    className="text-gray-400 hover:text-academic-gold transition-colors text-sm"
+                                    className="text-academic-medium-blue dark:text-academic-off-white hover:text-academic-gold transition-colors text-sm"
                                 >
                                     Personalized Learning
                                 </button>
@@ -80,7 +80,7 @@ export default function Footer () {
                             <li>
                                 <button
                                     onClick={() => scrollToSection('contact')}
-                                    className="text-gray-400 hover:text-academic-gold transition-colors text-sm"
+                                    className="text-academic-medium-blue dark:text-academic-off-white hover:text-academic-gold transition-colors text-sm"
                                 >
                                     Free Consultation
                                 </button>
@@ -90,12 +90,12 @@ export default function Footer () {
 
                     {/* Test Types */}
                     <div>
-                        <h4 className="text-lg font-semibold text-white mb-6 title-font">Test Types</h4>
+                        <h4 className="text-lg font-semibold mb-6 title-font">Test Types</h4>
                         <ul className="space-y-3">
-                            <li className="text-gray-400 text-sm">SAT Prep</li>
-                            <li className="text-gray-400 text-sm">ACT Prep</li>
-                            <li className="text-gray-400 text-sm">SAT Subject Tests</li>
-                            <li className="text-gray-400 text-sm">Academic Tutoring</li>
+                            <li className="text-academic-medium-blue dark:text-academic-off-white text-sm">SAT Prep</li>
+                            <li className="text-academic-medium-blue dark:text-academic-off-white text-sm">ACT Prep</li>
+                            <li className="text-academic-medium-blue dark:text-academic-off-white text-sm">SAT Subject Tests</li>
+                            <li className="text-academic-medium-blue dark:text-academic-off-white text-sm">Academic Tutoring</li>
                             <li className="text-academic-gold text-sm font-medium">Almost All Subjects Covered</li>
                         </ul>
                     </div>
@@ -105,8 +105,8 @@ export default function Footer () {
                 <div className="border-t border-academic-medium-blue/30 py-8">
                     <div className="flex flex-col sm:flex-row items-center justify-between gap-6">
                         <div className="text-center sm:text-left">
-                            <h4 className="text-lg font-semibold text-white mb-2 title-font">Start Your Academic Success Today</h4>
-                            <p className="text-gray-400 text-sm">Get the best tutoring support in the Bay Area</p>
+                            <h4 className="text-lg font-semibold mb-2 title-font">Start Your Academic Success Today</h4>
+                            <p className="text-academic-medium-blue dark:text-academic-off-white text-sm">Get the best tutoring support in the Bay Area</p>
                         </div>
                         <div className="flex flex-col sm:flex-row items-center gap-4">
                             <button
@@ -120,12 +120,12 @@ export default function Footer () {
                     </div>
                 </div>
 
-                <p className="text-center text-xs text-gray-400 mt-4">*In-person sessions may include additional travel fees.</p>
+                <p className="text-center text-xs text-academic-medium-blue dark:text-academic-off-white mt-4">*In-person sessions may include additional travel fees.</p>
 
                 {/* Bottom Bar */}
                 <div className="border-t border-academic-medium-blue/30 py-6">
                     <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
-                        <div className="flex flex-col sm:flex-row items-center gap-4 text-sm text-gray-400">
+                        <div className="flex flex-col sm:flex-row items-center gap-4 text-sm text-academic-medium-blue dark:text-academic-off-white">
                             <span>&copy; {new Date().getFullYear()} Bay Area Academic Tutor. All rights reserved.</span>
                             <span className="hidden sm:block">•</span>
                             <span>UC Berkeley Graduate • 15+ Years Experience • Bay Area Expert</span>
@@ -133,7 +133,7 @@ export default function Footer () {
 
                         <button
                             onClick={scrollToTop}
-                            className="flex items-center space-x-2 text-gray-400 hover:text-academic-gold transition-colors text-sm"
+                            className="flex items-center space-x-2 text-academic-medium-blue dark:text-academic-off-white hover:text-academic-gold transition-colors text-sm"
                         >
                             <span>Back to Top</span>
                             <ArrowUp className="w-4 h-4" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { Menu, X, Calendar } from 'lucide-react'
 import { useCal } from './CalProvider'
+import ThemeToggle from './ThemeToggle'
 
 export default function Header () {
     const [ isScrolled, setIsScrolled ] = useState(false)
@@ -55,7 +56,7 @@ export default function Header () {
             <header
                 className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
                     isScrolled
-                        ? 'bg-academic-navy/95 backdrop-blur-md shadow-lg'
+                        ? 'bg-academic-off-white/95 dark:bg-academic-navy/95 backdrop-blur-md shadow-lg'
                         : 'bg-transparent'
                 }`}
             >
@@ -72,19 +73,19 @@ export default function Header () {
                         <div className="hidden lg:flex items-center space-x-8">
                             <button
                                 onClick={() => scrollToSection('services')}
-                                className="text-white hover:text-academic-gold transition-colors font-medium"
+                                className="text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium"
                             >
                                 Services
                             </button>
                             <button
                                 onClick={() => scrollToSection('about')}
-                                className="text-white hover:text-academic-gold transition-colors font-medium"
+                                className="text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium"
                             >
                                 About
                             </button>
                             <button
                                 onClick={() => scrollToSection('faq')}
-                                className="text-white hover:text-academic-gold transition-colors font-medium"
+                                className="text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium"
                             >
                                 FAQ
                             </button>
@@ -95,12 +96,13 @@ export default function Header () {
                                 <Calendar className="w-4 h-4" />
                                 <span>Schedule Now</span>
                             </button>
+                            <ThemeToggle />
                         </div>
 
                         {/* Mobile Menu Button */}
                         <button
                             onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-                            className="lg:hidden text-white p-2"
+                            className="lg:hidden text-academic-navy dark:text-white p-2"
                         >
                             {isMobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
                         </button>
@@ -108,22 +110,22 @@ export default function Header () {
 
                     {/* Mobile Navigation */}
                     {isMobileMenuOpen && (
-                        <div className="lg:hidden bg-academic-dark-blue/95 backdrop-blur-md rounded-lg mt-2 p-4 space-y-4">
+                        <div className="lg:hidden bg-academic-off-white/95 dark:bg-academic-dark-blue/95 backdrop-blur-md rounded-lg mt-2 p-4 space-y-4">
                             <button
                                 onClick={() => scrollToSection('services')}
-                                className="block w-full text-left text-white hover:text-academic-gold transition-colors font-medium py-2"
+                                className="block w-full text-left text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium py-2"
                             >
                                 Services
                             </button>
                             <button
                                 onClick={() => scrollToSection('about')}
-                                className="block w-full text-left text-white hover:text-academic-gold transition-colors font-medium py-2"
+                                className="block w-full text-left text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium py-2"
                             >
                                 About
                             </button>
                             <button
                                 onClick={() => scrollToSection('faq')}
-                                className="block w-full text-left text-white hover:text-academic-gold transition-colors font-medium py-2"
+                                className="block w-full text-left text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium py-2"
                             >
                                 FAQ
                             </button>
@@ -134,6 +136,9 @@ export default function Header () {
                                 <Calendar className="w-4 h-4" />
                                 <span>Schedule Now</span>
                             </button>
+                            <div className="flex justify-center">
+                                <ThemeToggle />
+                            </div>
                         </div>
                     )}
                 </nav>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -14,10 +14,10 @@ export default function Hero () {
     const { open } = useCal()
 
     return (
-        <section className="relative min-h-screen flex items-center justify-center overflow-hidden">
+        <section className="relative min-h-screen flex items-center justify-center overflow-hidden bg-background dark:bg-academic-navy">
             {/* Academic-style gradient background */}
-            <div className="absolute inset-0 bg-gradient-to-br from-academic-navy via-academic-dark-blue to-academic-navy">
-                <div className="absolute inset-0 bg-gradient-to-r from-academic-gold/10 via-transparent to-academic-gold/5"></div>
+            <div className="absolute inset-0 bg-gradient-to-br from-academic-off-white via-academic-light-blue/20 to-academic-off-white dark:from-academic-navy dark:via-academic-dark-blue dark:to-academic-navy">
+                <div className="absolute inset-0 dark:bg-gradient-to-r dark:from-academic-gold/10 dark:via-transparent dark:to-academic-gold/5"></div>
             </div>
 
             {/* Subtle background elements */}
@@ -33,25 +33,25 @@ export default function Hero () {
                     {/* Badge */}
                     <div className="inline-flex items-center space-x-2 bg-academic-gold/20 backdrop-blur-sm border border-academic-gold/30 rounded-full px-4 py-2 mb-8 animate-fade-in">
                         <AcademicIcon />
-                        <span className="text-sm font-medium text-white">UC Berkeley Graduate • 15+ Years Experience</span>
+                        <span className="text-sm font-medium text-foreground dark:text-white">UC Berkeley Graduate • 15+ Years Experience</span>
                     </div>
 
                     {/* Main Heading */}
                     <h1 className="text-4xl sm:text-5xl lg:text-7xl font-bold mb-6 animate-slide-up title-font">
-                        <span className="block text-white leading-tight">Bay Area's</span>
-                        <span className="block text-gradient leading-tight">Premier Tutor</span>
+                        <span className="block text-foreground dark:text-white leading-tight">Bay Area's</span>
+                        <span className="block text-academic-gold dark:text-gradient leading-tight">Premier Tutor</span>
                     </h1>
 
                     {/* Subheading */}
-                    <p className="text-lg sm:text-xl lg:text-2xl text-gray-300 mb-8 max-w-4xl mx-auto animate-slide-up delay-200 leading-relaxed">
+                    <p className="text-lg sm:text-xl lg:text-2xl text-academic-medium-blue dark:text-academic-off-white mb-8 max-w-4xl mx-auto animate-slide-up delay-200 leading-relaxed">
                         You deserve the best academic support. I provide expert tutoring for SAT, ACT, SAT Subject Tests,
                         and comprehensive school support. Familiar with Bay Area curricula and teachers.
                     </p>
 
                     {/* Location Badge */}
-                    <div className="inline-flex items-center space-x-2 bg-academic-medium-blue/50 backdrop-blur-sm border border-academic-gold/20 rounded-full px-4 py-2 mb-8 animate-slide-up delay-300">
+                    <div className="inline-flex items-center space-x-2 bg-blue-100 dark:bg-academic-medium-blue/50 backdrop-blur-sm border border-academic-gold/20 rounded-full px-4 py-2 mb-8 animate-slide-up delay-300">
                         <MapPin className="w-4 h-4 text-academic-gold" />
-                        <span className="text-sm text-white">In-Person* & Online • Bay Area Libraries & Your Home</span>
+                        <span className="text-sm text-foreground dark:text-white">In-Person* & Online • Bay Area Libraries & Your Home</span>
                     </div>
 
                     {/* CTA Buttons */}
@@ -68,7 +68,7 @@ export default function Hero () {
                                 const element = document.getElementById('services')
                                 if (element) element.scrollIntoView({ behavior: 'smooth' })
                             }}
-                            className="px-8 py-4 text-lg font-semibold rounded-lg border-2 border-white/20 hover:border-academic-gold/50 text-white hover:bg-academic-gold/10 transition-all duration-300 w-full sm:w-auto"
+                            className="px-8 py-4 text-lg font-semibold rounded-lg border-2 border-academic-navy/20 dark:border-white/20 text-foreground dark:text-white hover:border-academic-gold/50 hover:bg-academic-gold/10 transition-all duration-300 w-full sm:w-auto"
                         >
                             View Services
                         </button>
@@ -78,19 +78,19 @@ export default function Hero () {
                     <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 max-w-3xl mx-auto animate-slide-up delay-500">
                         <div className="text-center">
                             <div className="text-2xl sm:text-3xl font-bold text-academic-gold mb-1 title-font">15+</div>
-                            <div className="text-sm text-gray-400">Years Experience</div>
+                            <div className="text-sm text-academic-medium-blue dark:text-academic-off-white">Years Experience</div>
                         </div>
                         <div className="text-center">
                             <div className="text-2xl sm:text-3xl font-bold text-academic-gold mb-1 title-font">All</div>
-                            <div className="text-sm text-gray-400">Test Types</div>
+                            <div className="text-sm text-academic-medium-blue dark:text-academic-off-white">Test Types</div>
                         </div>
                         <div className="text-center">
                             <div className="text-2xl sm:text-3xl font-bold text-academic-gold mb-1 title-font">Local</div>
-                            <div className="text-sm text-gray-400">Schools Known</div>
+                            <div className="text-sm text-academic-medium-blue dark:text-academic-off-white">Schools Known</div>
                         </div>
                         <div className="text-center">
                             <div className="text-2xl sm:text-3xl font-bold text-academic-gold mb-1 title-font">Care</div>
-                            <div className="text-sm text-gray-400">& Attention</div>
+                            <div className="text-sm text-academic-medium-blue dark:text-academic-off-white">& Attention</div>
                         </div>
                     </div>
                 </div>

--- a/src/components/Pricing.tsx
+++ b/src/components/Pricing.tsx
@@ -6,13 +6,13 @@ import { siteContent } from '@/data/siteContent'
 export default function Pricing () {
   const { heading, subheading, plans } = siteContent.pricing
   return (
-    <section id="pricing" className="py-16 bg-white">
+    <section id="pricing" className="py-16 bg-background dark:bg-academic-navy">
       <div className="container mx-auto px-4">
         <div className="text-center mb-12">
-          <h2 className="text-3xl md:text-4xl font-bold text-academic-navy mb-3">
+          <h2 className="text-3xl md:text-4xl font-bold text-foreground dark:text-academic-off-white mb-3">
             {heading}
           </h2>
-          <p className="text-xl text-academic-dark-blue max-w-3xl mx-auto">{subheading}</p>
+          <p className="text-xl text-academic-medium-blue dark:text-academic-off-white max-w-3xl mx-auto">{subheading}</p>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-5xl mx-auto">
           {plans.map((plan) => (

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -60,14 +60,14 @@ export default function Services () {
     ]
 
     return (
-        <section id="services" className="py-20 lg:py-32 bg-academic-dark-blue">
+        <section id="services" className="py-20 lg:py-32 bg-background dark:bg-academic-dark-blue">
             <div className="container mx-auto px-4 sm:px-6 lg:px-8">
                 <div className="text-center mb-16">
                     <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6 title-font">
-                        <span className="text-white">Comprehensive Tutoring</span>
-                        <span className="block text-gradient">Services</span>
+                        <span className="text-foreground dark:text-white">Comprehensive Tutoring</span>
+                        <span className="block text-academic-gold dark:text-gradient">Services</span>
                     </h2>
-                    <p className="text-lg sm:text-xl text-gray-300 max-w-3xl mx-auto">
+                    <p className="text-lg sm:text-xl text-academic-medium-blue dark:text-academic-off-white max-w-3xl mx-auto">
                         You get expert support for standardized tests and academic success. I provide personalized tutoring that works with your schedule and learning style.
                     </p>
                 </div>
@@ -79,15 +79,15 @@ export default function Services () {
                             <div className="text-academic-gold mb-6">
                                 {service.icon}
                             </div>
-                            <h3 className="text-xl font-bold text-white mb-4 title-font">
+                            <h3 className="text-xl font-bold text-foreground dark:text-white mb-4 title-font">
                                 {service.title}
                             </h3>
-                            <p className="text-gray-300 mb-6 leading-relaxed">
+                            <p className="text-academic-medium-blue dark:text-academic-off-white mb-6 leading-relaxed">
                                 {service.description}
                             </p>
                             <ul className="space-y-2">
                                 {service.features.map((feature, idx) => (
-                                    <li key={idx} className="text-sm text-gray-400 flex items-start">
+                                    <li key={idx} className="text-sm text-academic-medium-blue dark:text-academic-off-white flex items-start">
                                         <div className="w-2 h-2 bg-academic-gold rounded-full mt-1 mr-3 flex-shrink-0"></div>
                                         {feature}
                                     </li>
@@ -98,26 +98,26 @@ export default function Services () {
                 </div>
 
                 {/* Test Types & Academic Support */}
-                <div className="bg-academic-medium-blue/50 backdrop-blur-sm rounded-2xl p-8 lg:p-12 mb-20">
+                <div className="bg-blue-100 dark:bg-academic-medium-blue/50 backdrop-blur-sm rounded-2xl p-8 lg:p-12 mb-20">
                     <div className="text-center mb-12">
-                        <h3 className="text-2xl lg:text-3xl font-bold text-white mb-4 title-font">
+                        <h3 className="text-2xl lg:text-3xl font-bold text-foreground dark:text-white mb-4 title-font">
                             Complete Test Prep & Academic Support
                         </h3>
-                        <p className="text-lg text-gray-300">
+                        <p className="text-lg text-academic-medium-blue dark:text-academic-off-white">
                             You'll master every test type and subject with expert guidance
                         </p>
                     </div>
 
                     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
                         {testTypes.map((test, index) => (
-                            <div key={index} className="bg-academic-navy/30 rounded-xl p-6 border border-academic-gold/20 hover:border-academic-gold/40 transition-all duration-300">
+                            <div key={index} className="bg-blue-200 dark:bg-academic-dark-blue rounded-xl p-6 border border-academic-gold/20 hover:border-academic-gold/40 transition-all duration-300">
                                 <div className="text-academic-gold mb-4">
                                     {test.icon}
                                 </div>
-                                <h4 className="text-lg font-semibold text-white mb-2 title-font">
+                                <h4 className="text-lg font-semibold text-foreground dark:text-white mb-2 title-font">
                                     {test.name}
                                 </h4>
-                                <p className="text-sm text-gray-400">
+                                <p className="text-sm text-academic-medium-blue dark:text-academic-off-white">
                                     {test.topics}
                                 </p>
                             </div>
@@ -127,10 +127,10 @@ export default function Services () {
 
                 {/* Tutoring Locations */}
                 <div className="text-center mb-12">
-                    <h3 className="text-2xl lg:text-3xl font-bold text-white mb-4 title-font">
+                    <h3 className="text-2xl lg:text-3xl font-bold text-foreground dark:text-white mb-4 title-font">
                         Flexible Learning Locations
                     </h3>
-                    <p className="text-lg text-gray-300">
+                    <p className="text-lg text-academic-medium-blue dark:text-academic-off-white">
                         Choose the environment that works best for you
                     </p>
                 </div>
@@ -149,23 +149,23 @@ export default function Services () {
                             <div className="text-academic-gold mb-4 flex justify-center">
                                 {location.icon}
                             </div>
-                            <h4 className="text-lg font-semibold text-white mb-2 title-font">
+                            <h4 className="text-lg font-semibold text-foreground dark:text-white mb-2 title-font">
                                 {location.name}
                             </h4>
-                            <p className="text-sm text-gray-400">
+                            <p className="text-sm text-academic-medium-blue dark:text-academic-off-white">
                                 {location.description}
                             </p>
                         </div>
                     ))}
                 </div>
-                <p className="mt-6 text-center text-xs text-gray-400">
+                <p className="mt-6 text-center text-xs text-academic-medium-blue dark:text-academic-off-white">
                     *In-person sessions may include additional travel fees.
                 </p>
 
                 <div className="mt-12 text-center">
                     <div className="inline-flex items-center space-x-2 bg-academic-gold/20 backdrop-blur-sm border border-academic-gold/30 rounded-full px-6 py-3">
                         <Globe className="w-5 h-5 text-academic-gold" />
-                        <span className="text-white font-medium">Serving the entire Bay Area and beyond</span>
+                        <span className="text-foreground dark:text-white font-medium">Serving the entire Bay Area and beyond</span>
                     </div>
                 </div>
             </div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useTheme } from 'next-themes'
+import { Sun, Moon } from 'lucide-react'
+
+export default function ThemeToggle () {
+    const { resolvedTheme, setTheme } = useTheme()
+    const [ mounted, setMounted ] = useState(false)
+
+    useEffect(() => setMounted(true), [])
+    if (!mounted) return null
+
+    const toggleTheme = () => {
+        setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
+    }
+
+    return (
+        <button
+            onClick={toggleTheme}
+            aria-label="Toggle dark mode"
+            className="p-2 rounded focus:outline-none focus:ring-2 focus:ring-academic-gold"
+        >
+            {resolvedTheme === 'dark'
+                ? <Sun className="w-5 h-5 text-academic-gold" />
+                : <Moon className="w-5 h-5 text-academic-gold" />}
+        </button>
+    )
+}

--- a/src/components/ui/PricingCard.tsx
+++ b/src/components/ui/PricingCard.tsx
@@ -10,7 +10,7 @@ interface PricingCardProps {
 const PricingCard = ({ plan }: PricingCardProps) => {
     const { open } = useCal();
     return (
-        <div className={`bg-white rounded-lg shadow-lg overflow-hidden border flex flex-col ${plan.popular ? 'border-academic-gold transform scale-105 z-10' : 'border-academic-navy/20'} transition-all hover:shadow-xl`}>
+        <div className={`academic-card rounded-lg shadow-lg overflow-hidden border flex flex-col ${plan.popular ? 'border-academic-gold transform scale-105 z-10' : 'border-academic-navy/20 dark:border-academic-off-white/20'} transition-all hover:shadow-xl`}>
             {plan.popular && (
                 <div className="bg-academic-gold text-academic-navy text-center py-1 text-sm font-medium">
                     Most Popular
@@ -18,18 +18,18 @@ const PricingCard = ({ plan }: PricingCardProps) => {
             )}
 
             <div className="p-6 flex flex-col flex-grow">
-                <h3 className="text-xl font-bold text-academic-navy mb-2">{plan.name}</h3>
+                <h3 className="text-xl font-bold text-foreground dark:text-white mb-2">{plan.name}</h3>
 
                 <div className="flex items-baseline mb-6">
-                    <span className="text-4xl font-bold text-academic-navy">${plan.price}</span>
-                    <span className="text-academic-dark-blue ml-1">{plan.unit}</span>
+                    <span className="text-4xl font-bold text-foreground dark:text-white">${plan.price}</span>
+                    <span className="text-academic-medium-blue dark:text-academic-off-white ml-1">{plan.unit}</span>
                 </div>
 
                 <ul className="space-y-3 mb-8 flex-grow">
                     {plan.features.map((feature, index) => (
                         <li key={index} className="flex items-center">
                             <Check className="w-5 h-5 text-academic-gold mr-2 flex-shrink-0" />
-                            <span className="text-academic-dark-blue">{feature}</span>
+                            <span className="text-academic-medium-blue dark:text-academic-off-white">{feature}</span>
                         </li>
                     ))}
                 </ul>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+    darkMode: 'class',
     content: [
         './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
         './src/components/**/*.{js,ts,jsx,tsx,mdx}',
@@ -17,9 +18,12 @@ module.exports = {
                     'light-gold': '#E6C757',
                     'dark-gold': '#B8941F',
                     white: '#FFFFFF',
-                    'off-white': '#F8F9FA',
+                    'off-white': '#F5F1E6',
                     gray: '#6C757D',
-                }
+                },
+                background: 'var(--background)',
+                foreground: 'var(--foreground)',
+                muted: 'var(--muted)',
             },
             fontFamily: {
                 'title': ['Playfair Display', 'serif'],


### PR DESCRIPTION
## Summary
- expose background, foreground, and muted CSS variables to Tailwind and theme-aware card styles
- apply light and dark backgrounds and accessible text colors across major sections
- update layout to default to variable-based colors
- restore blue titles and replace gray accents with blue tones over a parchment light theme
- respect system color scheme by default and keep ThemeToggle icon in sync

## Testing
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a6d25ced98832bb1dcfde9df20f9c3