### PR TITLE
Add production-ready PostHog analytics integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,56 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Analytics
+
+### Installation
+
+```
+npm install posthog-js
+```
+
+### Setup
+
+1. Ensure user consent is granted by calling `grantConsent()` from `analytics/utils.js`.
+2. Place `<AnalyticsProvider />` inside the application layout (`src/app/layout.tsx`).
+3. Use event helpers from `analytics/events.js` to track custom interactions.
+4. Access feature flags for A/B tests using `getFeatureFlag()` from `analytics/posthog.config.js`.
+
+### Event Usage Examples
+
+```javascript
+import {
+  trackButtonClick,
+  trackFormInteraction,
+  trackScrollPercentage,
+  trackNavigationEvent,
+  trackMediaInteraction,
+  trackProductViewed,
+  trackAddToCart,
+  trackPurchase
+} from '../analytics/events'
+
+// manual examples (page views are automatic)
+trackButtonClick({ button_text: 'Subscribe', page_location: '/home', timestamp: Date.now() })
+trackFormInteraction({ form_name: 'contact', field_name: 'email', action_type: 'input', timestamp: Date.now() })
+trackScrollPercentage({ scroll_percentage: 50, timestamp: Date.now() })
+trackNavigationEvent({ type: 'search_query', value: 'tutors', page_location: '/search', timestamp: Date.now() })
+trackMediaInteraction({ media_type: 'video_play', element: 'intro.mp4', timestamp: Date.now() })
+trackProductViewed({ product_id: 'sku-1', product_name: 'Premium Course', price: 199, timestamp: Date.now() })
+trackAddToCart({ product_id: 'sku-1', quantity: 1, price: 199, timestamp: Date.now() })
+trackPurchase({ order_id: 'order-1', total: 199, products: [{ product_id: 'sku-1', quantity: 1, price: 199 }], timestamp: Date.now() })
+```
+
+### Testing
+
+- Click buttons, submit forms, scroll and play media; confirm corresponding events in PostHog Live view.
+- Run `npm run lint` to verify code style.
+- Start the development server with `npm run dev` and interact with the site to confirm events are sent to PostHog.
+
+### Troubleshooting
+
+- Verify that the PostHog key and host in `analytics/posthog.config.js` are correct.
+- Ensure consent is granted before initialization.
+- Check the browser console for initialization errors.
+- Network requests to `https://us.posthog.com` should be visible after interactions.

--- a/analytics/events.js
+++ b/analytics/events.js
@@ -1,0 +1,69 @@
+import { captureEvent } from './utils.js'
+
+export const EVENTS = {
+    PAGE_VIEW: 'page_view',
+    BUTTON_CLICK: 'button_click',
+    FORM_INTERACTION: 'form_interaction',
+    PRODUCT_VIEWED: 'product_viewed',
+    ADD_TO_CART: 'add_to_cart',
+    PURCHASE: 'purchase',
+    SCROLL_DEPTH: 'scroll_depth',
+    TIME_ON_PAGE: 'time_on_page',
+    SESSION_DURATION: 'session_duration',
+    NAVIGATION: 'navigation',
+    MEDIA_INTERACTION: 'media_interaction',
+    HOVER: 'hover',
+    KEYBOARD: 'keyboard_input',
+}
+
+export function trackPageView (props) {
+    captureEvent(EVENTS.PAGE_VIEW, props)
+}
+
+export function trackButtonClick (props) {
+    captureEvent(EVENTS.BUTTON_CLICK, props)
+}
+
+export function trackFormInteraction (props) {
+    captureEvent(EVENTS.FORM_INTERACTION, props)
+}
+
+export function trackProductViewed (props) {
+    captureEvent(EVENTS.PRODUCT_VIEWED, props)
+}
+
+export function trackAddToCart (props) {
+    captureEvent(EVENTS.ADD_TO_CART, props)
+}
+
+export function trackPurchase (props) {
+    captureEvent(EVENTS.PURCHASE, props)
+}
+
+export function trackScrollPercentage (props) {
+    captureEvent(EVENTS.SCROLL_DEPTH, props)
+}
+
+export function trackTimeOnPage (props) {
+    captureEvent(EVENTS.TIME_ON_PAGE, props)
+}
+
+export function trackSessionDuration (props) {
+    captureEvent(EVENTS.SESSION_DURATION, props)
+}
+
+export function trackNavigationEvent (props) {
+    captureEvent(EVENTS.NAVIGATION, props)
+}
+
+export function trackMediaInteraction (props) {
+    captureEvent(EVENTS.MEDIA_INTERACTION, props)
+}
+
+export function trackHover (props) {
+    captureEvent(EVENTS.HOVER, props)
+}
+
+export function trackKeyboard (props) {
+    captureEvent(EVENTS.KEYBOARD, props)
+}

--- a/analytics/posthog.config.js
+++ b/analytics/posthog.config.js
@@ -1,0 +1,44 @@
+import posthog from 'posthog-js'
+
+const POSTHOG_KEY = 'phc_VZX1tioRIHsGxMdBVLlW7PEKGOw13antIazxQHTM7V0'
+const POSTHOG_HOST = 'https://us.posthog.com'
+
+const isProd = process.env.NODE_ENV === 'production'
+let initialized = false
+
+function hasConsent () {
+    try {
+        return localStorage.getItem('ph_consent') === 'true'
+    } catch {
+        return false
+    }
+}
+
+export function initPostHog () {
+    if (typeof window === 'undefined' || initialized || !hasConsent()) return
+    try {
+        posthog.init(POSTHOG_KEY, {
+            api_host: POSTHOG_HOST,
+            capture_pageview: false,
+            autocapture: false,
+            session_recording: {
+                maskAllInputs: false,
+            },
+            debug: !isProd,
+        })
+        initialized = true
+    } catch (error) {
+        console.error('PostHog initialization failed', error)
+    }
+}
+
+export function getFeatureFlag (flag) {
+    try {
+        return posthog.isFeatureEnabled(flag)
+    } catch (error) {
+        console.error('Feature flag check failed', error)
+        return false
+    }
+}
+
+export { posthog }

--- a/analytics/tracking.hooks.js
+++ b/analytics/tracking.hooks.js
@@ -1,0 +1,116 @@
+'use client';
+import { useEffect } from 'react'
+import { initPostHog } from './posthog.config.js'
+import {
+    trackPageView,
+    trackButtonClick,
+    trackFormInteraction,
+    trackScrollPercentage,
+    trackSessionDuration,
+    trackNavigationEvent,
+    trackMediaInteraction,
+    trackHover,
+    trackKeyboard,
+} from './events.js'
+import { identifyUser, setupErrorTracking, timeOnPage, resetTimer, trackPerformance } from './utils.js'
+
+export function useAnalytics (userId) {
+    useEffect(() => {
+        initPostHog()
+        trackPerformance()
+        setupErrorTracking()
+        if (userId) identifyUser(userId)
+
+        trackPageView({
+            url: window.location.href,
+            referrer: document.referrer,
+            timestamp: Date.now(),
+            user_id: userId,
+        })
+
+        const clickHandler = e => {
+            const target = e.target.closest('button, a, img')
+            const page_location = window.location.pathname
+            const timestamp = Date.now()
+            if (target) {
+                if (target.tagName === 'BUTTON') {
+                    trackButtonClick({ button_text: target.textContent || 'button', page_location, timestamp })
+                } else if (target.tagName === 'A') {
+                    const text = target.textContent || target.href
+                    trackNavigationEvent({ type: 'menu_click', value: text, page_location, timestamp })
+                    if (target.getAttribute('download') !== null) {
+                        trackMediaInteraction({ media_type: 'download_started', element: target.href, timestamp })
+                    }
+                } else if (target.tagName === 'IMG') {
+                    trackMediaInteraction({ media_type: 'image_click', element: target.src, timestamp })
+                }
+            }
+        }
+
+        const submitHandler = e => {
+            const form = e.target
+            const form_name = form.getAttribute('name') || form.getAttribute('id') || 'form'
+            const timestamp = Date.now()
+            Array.from(form.elements).forEach(el => {
+                if (el.name) {
+                    trackFormInteraction({ form_name, field_name: el.name, action_type: 'submit', timestamp })
+                }
+            })
+        }
+
+        const scrollHandler = () => {
+            const scrollTop = window.scrollY + window.innerHeight
+            const height = document.documentElement.scrollHeight
+            const scroll_percentage = Math.round((scrollTop / height) * 100)
+            trackScrollPercentage({ scroll_percentage, timestamp: Date.now() })
+        }
+
+        const mouseoverHandler = e => {
+            const element = e.target
+            if (element instanceof HTMLElement) {
+                trackHover({ element: element.tagName.toLowerCase(), page_location: window.location.pathname, timestamp: Date.now() })
+            }
+        }
+
+        const keyHandler = e => {
+            trackKeyboard({ key: e.key, page_location: window.location.pathname, timestamp: Date.now() })
+        }
+
+        const playHandler = e => {
+            const element = e.target
+            if (element instanceof HTMLVideoElement) {
+                trackMediaInteraction({ media_type: 'video_play', element: element.currentSrc, timestamp: Date.now() })
+            }
+        }
+
+        const beforeUnload = () => {
+            timeOnPage()
+            trackSessionDuration({ session_duration: Date.now() - performance.timeOrigin, timestamp: Date.now() })
+            resetTimer()
+        }
+
+        window.addEventListener('click', clickHandler, true)
+        window.addEventListener('submit', submitHandler, true)
+        window.addEventListener('scroll', scrollHandler)
+        window.addEventListener('mouseover', mouseoverHandler)
+        window.addEventListener('keydown', keyHandler)
+        window.addEventListener('play', playHandler, true)
+        window.addEventListener('beforeunload', beforeUnload)
+
+        return () => {
+            window.removeEventListener('click', clickHandler, true)
+            window.removeEventListener('submit', submitHandler, true)
+            window.removeEventListener('scroll', scrollHandler)
+            window.removeEventListener('mouseover', mouseoverHandler)
+            window.removeEventListener('keydown', keyHandler)
+            window.removeEventListener('play', playHandler, true)
+            window.removeEventListener('beforeunload', beforeUnload)
+            resetTimer()
+        }
+    }, [userId])
+}
+
+export function AnalyticsProvider ({ userId }) {
+    useAnalytics(userId)
+    return null
+}

--- a/analytics/types.d.ts
+++ b/analytics/types.d.ts
@@ -1,0 +1,80 @@
+export interface PageViewEvent {
+    url: string
+    referrer: string
+    timestamp: number
+    user_id?: string
+}
+
+export interface ButtonClickEvent {
+    button_text: string
+    page_location: string
+    timestamp: number
+}
+
+export interface FormInteractionEvent {
+    form_name: string
+    field_name: string
+    action_type: string
+    timestamp: number
+}
+
+export interface ProductViewedEvent {
+    product_id: string
+    product_name: string
+    price?: number
+    timestamp: number
+}
+
+export interface AddToCartEvent {
+    product_id: string
+    quantity: number
+    price?: number
+    timestamp: number
+}
+
+export interface PurchaseEvent {
+    order_id: string
+    total: number
+    products: Array<{ product_id: string; quantity: number; price: number }>
+    timestamp: number
+}
+
+export interface ScrollDepthEvent {
+    scroll_percentage: number
+    timestamp: number
+}
+
+export interface TimeOnPageEvent {
+    duration: number
+    timestamp: number
+}
+
+export interface SessionDurationEvent {
+    session_duration: number
+    timestamp: number
+}
+
+export interface NavigationEvent {
+    type: 'menu_click' | 'search_query' | 'filter_applied'
+    value: string
+    page_location: string
+    timestamp: number
+}
+
+export interface MediaInteractionEvent {
+    media_type: 'video_play' | 'image_click' | 'download_started'
+    element: string
+    timestamp: number
+}
+
+export interface HoverEvent {
+    element: string
+    page_location: string
+    timestamp: number
+}
+
+export interface KeyboardInputEvent {
+    key: string
+    page_location: string
+    timestamp: number
+}

--- a/analytics/utils.js
+++ b/analytics/utils.js
@@ -1,0 +1,77 @@
+import posthog from 'posthog-js'
+import { initPostHog } from './posthog.config.js'
+
+const CONSENT_KEY = 'ph_consent'
+let pageStart = Date.now()
+
+export function captureEvent (name, properties = {}) {
+    try {
+        posthog.capture(name, properties)
+    } catch (error) {
+        console.error('Capture failed', error)
+    }
+}
+
+export function identifyUser (id, properties = {}) {
+    try {
+        posthog.identify(id, properties)
+    } catch (error) {
+        console.error('Identify failed', error)
+    }
+}
+
+export function setUserProperties (properties) {
+    try {
+        posthog.people.set(properties)
+    } catch (error) {
+        console.error('Setting user properties failed', error)
+    }
+}
+
+export function setupErrorTracking () {
+    window.addEventListener('error', e => {
+        captureEvent('javascript_error', { message: e.message, stack: e.error?.stack })
+    })
+    window.addEventListener('unhandledrejection', e => {
+        captureEvent('unhandled_rejection', { message: e.reason?.message || String(e.reason) })
+    })
+}
+
+export function grantConsent () {
+    localStorage.setItem(CONSENT_KEY, 'true')
+    posthog.opt_in_capturing()
+    initPostHog()
+}
+
+export function revokeConsent () {
+    localStorage.setItem(CONSENT_KEY, 'false')
+    posthog.opt_out_capturing()
+}
+
+export function hasConsent () {
+    try {
+        return localStorage.getItem(CONSENT_KEY) === 'true'
+    } catch {
+        return false
+    }
+}
+
+export function trackPerformance () {
+    try {
+        const { loadEventEnd, navigationStart } = performance.timing
+        const duration = loadEventEnd - navigationStart
+        captureEvent('performance', { duration })
+    } catch (error) {
+        console.error('Performance tracking failed', error)
+    }
+}
+
+export function timeOnPage () {
+    const now = Date.now()
+    const duration = now - pageStart
+    captureEvent('time_on_page', { duration, timestamp: now })
+}
+
+export function resetTimer () {
+    pageStart = Date.now()
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "next": "^14.2.32",
         "next-themes": "^0.3.0",
+        "posthog-js": "^1.260.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sharp": "^0.33.2"
@@ -2321,6 +2322,17 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/core-js": {
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3431,6 +3443,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -5672,6 +5690,40 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/posthog-js": {
+      "version": "1.260.1",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.260.1.tgz",
+      "integrity": "sha512-DD8ZSRpdScacMqtqUIvMFme8lmOWkOvExG8VvjONE7Cm3xpRH5xXpfrwMJE4bayTGWKMx4ij6SfphK6dm/o2ug==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "core-js": "^3.38.1",
+        "fflate": "^0.4.8",
+        "preact": "^10.19.3",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@rrweb/types": "2.0.0-alpha.17",
+        "rrweb-snapshot": "2.0.0-alpha.17"
+      },
+      "peerDependenciesMeta": {
+        "@rrweb/types": {
+          "optional": true
+        },
+        "rrweb-snapshot": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.27.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.1.tgz",
+      "integrity": "sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7252,6 +7304,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
   },
   "dependencies": {
     "next": "^14.2.32",
+    "next-themes": "^0.3.0",
+    "posthog-js": "^1.260.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "sharp": "^0.33.2",
-    "next-themes": "^0.3.0"
+    "sharp": "^0.33.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.8.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import { AnalyticsProvider } from '../../analytics/tracking.hooks'
 import { CalProvider } from '@/components/CalProvider'
 import { ThemeProvider } from 'next-themes'
 
@@ -82,6 +83,7 @@ export default function RootLayout ({
         </head>
         <body className="antialiased bg-background text-foreground">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+            <AnalyticsProvider />
             <CalProvider>
                 {children}
             </CalProvider>


### PR DESCRIPTION
## Summary
- integrate PostHog with explicit key/host and feature flag helpers
- add comprehensive event wrappers, consent handling and performance/error tracking
- document analytics usage with examples and hook into app layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a6f0414820832b958cd15dcf353bda