### PR TITLE
feat: display total package pricing

### DIFF
--- a/src/components/ui/PricingCard.tsx
+++ b/src/components/ui/PricingCard.tsx
@@ -25,7 +25,7 @@ const PricingCard = ({ plan }: PricingCardProps) => {
                     <span className="text-academic-medium-blue dark:text-academic-off-white ml-1">{plan.unit}</span>
                 </div>
 
-                <ul className="space-y-3 mb-8 flex-grow">
+                <ul className="space-y-3 mb-6 flex-grow">
                     {plan.features.map((feature, index) => (
                         <li key={index} className="flex items-center">
                             <Check className="w-5 h-5 text-academic-gold mr-2 flex-shrink-0" />
@@ -33,6 +33,19 @@ const PricingCard = ({ plan }: PricingCardProps) => {
                         </li>
                     ))}
                 </ul>
+
+                {plan.sessions && plan.sessions > 1 && (
+                    <div className="mb-6 text-center">
+                        <p className="text-lg font-semibold text-foreground dark:text-white">
+                            Total: ${plan.price * plan.sessions}
+                        </p>
+                        {plan.savings && (
+                            <p className="text-academic-medium-blue dark:text-academic-off-white text-sm">
+                                You save ${plan.savings}
+                            </p>
+                        )}
+                    </div>
+                )}
 
                 <Button
                     variant={plan.popular ? 'primary' : 'outline'}

--- a/src/data/siteContent.ts
+++ b/src/data/siteContent.ts
@@ -198,6 +198,7 @@ export const siteContent: SiteContent = {
                 name: "Single Session",
                 price: 85,
                 unit: "/hour",
+                sessions: 1,
                 features: [
                     "One-on-one personalized instruction",
                     "Flexible scheduling",
@@ -211,6 +212,8 @@ export const siteContent: SiteContent = {
                 price: 65,
                 unit: "/hour",
                 popular: true,
+                sessions: 16,
+                savings: 320,
                 features: [
                     "16 weekly sessions (one semester)",
                     "Best value for long-term improvement",
@@ -226,6 +229,8 @@ export const siteContent: SiteContent = {
                 price: 75,
                 unit: "/hour",
                 popular: false,
+                sessions: 10,
+                savings: 100,
                 features: [
                     "Save $100 compared to single sessions",
                     "Consistent weekly or bi-weekly sessions",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,8 @@ export interface PricingPlan {
     popular?: boolean;
     features: string[];
     cta: string;
+    sessions?: number;
+    savings?: number;
 }
 
 export interface FAQ {


### PR DESCRIPTION
## Summary
- show total price and savings for multi-session packages
- extend pricing data and types with session counts and savings

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a71c884110832bacfa194a64048de9