### PR TITLE
style: highlight savings banner and remove bundle totals

### DIFF
--- a/src/components/ui/PricingCard.tsx
+++ b/src/components/ui/PricingCard.tsx
@@ -34,16 +34,9 @@ const PricingCard = ({ plan }: PricingCardProps) => {
                     ))}
                 </ul>
 
-                {plan.sessions && plan.sessions > 1 && (
-                    <div className="mb-6 text-center">
-                        <p className="text-lg font-semibold text-foreground dark:text-white">
-                            Total: ${plan.price * plan.sessions}
-                        </p>
-                        {plan.savings && (
-                            <p className="text-academic-medium-blue dark:text-academic-off-white text-sm">
-                                You save ${plan.savings}
-                            </p>
-                        )}
+                {plan.sessions && plan.sessions > 1 && plan.savings && (
+                    <div className="mb-6 text-center bg-academic-gold text-academic-navy font-semibold py-2 rounded">
+                        You save ${plan.savings}
                     </div>
                 )}
 


### PR DESCRIPTION
## Summary
- highlight multi-session savings with gold banner
- remove total price line from bundle plans

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7ca879e38832b8aac48e9cb3656e0