### PR TITLE
Simplify hero location badge text

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -102,7 +102,7 @@ export default function Hero () {
                     {/* Location Badge */}
                     <div className="inline-flex items-center space-x-2 bg-blue-100 dark:bg-academic-medium-blue/50 backdrop-blur-sm border border-academic-gold/20 rounded-full px-4 py-2 mb-8 animate-slide-up delay-300">
                         <MapPin className="w-4 h-4 text-academic-gold" />
-                        <span className="text-sm text-foreground dark:text-white">In-Person* & Online • Bay Area Libraries & Your Home</span>
+                        <span className="text-sm text-foreground dark:text-white">In-Person* & Online</span>
                     </div>
 
                     {/* CTA Buttons */}


### PR DESCRIPTION
## Summary
- trim redundant location descriptor in hero banner to just "In-Person* & Online"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7cb010ad8832bac73d0076162ae76