### PR TITLE
Make desktop Cal modal overlay transparent

### DIFF
--- a/src/components/CalModal.tsx
+++ b/src/components/CalModal.tsx
@@ -9,7 +9,7 @@ interface CalModalProps {
 
 export default function CalModal ({ url, onClose }: CalModalProps) {
   return (
-    <div className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/60 backdrop-blur-md p-4 md:p-0">
+    <div className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/60 md:bg-transparent backdrop-blur-md p-4 md:p-0">
       <div className="w-full h-full md:h-[90vh] bg-white rounded-lg md:rounded-none overflow-hidden relative">
         <Button
           onClick={onClose}


### PR DESCRIPTION
## Summary
- Avoid solid overlay in desktop Cal modal by using a transparent background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a833d1a044832b9a7c458ca37b10ed