### PR TITLE
Allow transparent background for schedule modal iframe

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -192,3 +192,8 @@ body {
     max-height: 500px;
     transition: max-height 0.3s ease-in;
 }
+
+iframe[src*="schedule"] {
+    background: transparent !important;
+    background-color: transparent !important;
+}

--- a/src/components/CalModal.tsx
+++ b/src/components/CalModal.tsx
@@ -23,6 +23,7 @@ export default function CalModal ({ url, onClose }: CalModalProps) {
           src={url}
           className="w-full h-full border-0"
           title="Schedule"
+          allowTransparency
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- ensure scheduling iframe supports transparency with allowTransparency attr
- style schedule iframe to use transparent background

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a83a1a884c832bb99a1a6d8f81163c