### PR TITLE
Center online sessions card and refresh savings banner

### DIFF
--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -55,8 +55,8 @@ export default function Services () {
 
     const locations = [
         { icon: <Home className="w-6 h-6" />, name: "Your Home*", description: "Comfortable, familiar environment" },
-        { icon: <Building2 className="w-6 h-6" />, name: "Bay Area Libraries*", description: "Quiet, professional settings" },
-        { icon: <Monitor className="w-6 h-6" />, name: "Online Sessions", description: "Flexible, worldwide availability", popular: true }
+        { icon: <Monitor className="w-6 h-6" />, name: "Online Sessions", description: "Flexible, worldwide availability", popular: true },
+        { icon: <Building2 className="w-6 h-6" />, name: "Bay Area Libraries*", description: "Quiet, professional settings" }
     ]
 
     return (

--- a/src/components/ui/PricingCard.tsx
+++ b/src/components/ui/PricingCard.tsx
@@ -35,7 +35,7 @@ const PricingCard = ({ plan }: PricingCardProps) => {
                 </ul>
 
                 {plan.sessions && plan.sessions > 1 && plan.savings && (
-                    <div className="mb-6 text-center bg-academic-gold text-academic-navy font-semibold py-2 rounded">
+                    <div className="mb-6 text-center bg-academic-navy text-academic-gold font-semibold py-2 rounded-md shadow-md">
                         You save ${plan.savings}
                     </div>
                 )}


### PR DESCRIPTION
## Summary
- Reorder tutoring locations so "Online Sessions" appears in the middle with the popular styling.
- Restyle pricing "You save" notice with a sleek navy banner matching theme colors.

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac8a664ce4832bb989f713baca9beb