### PR TITLE
Clarify in-person pricing with consultation call-to-action

### DIFF
--- a/src/components/Pricing.tsx
+++ b/src/components/Pricing.tsx
@@ -2,6 +2,7 @@
 
 import PricingCard from './ui/PricingCard'
 import { siteContent } from '@/data/siteContent'
+import Button from './ui/Button'
 
 export default function Pricing () {
   const { heading, subheading, plans } = siteContent.pricing
@@ -20,7 +21,12 @@ export default function Pricing () {
           ))}
         </div>
       </div>
-        <p className="pt-3 text-center text-lg text-academic-medium-blue dark:text-academic-off-white mt-4">*In-person price adjustments are applied based on distance</p>
+      <div className="pt-3 text-center text-lg mt-4">
+        <p className="text-academic-medium-blue dark:text-academic-off-white mb-4">
+          In-person pricing is determined on a case-by-case basis. Schedule a consultation to discuss options.
+        </p>
+        <Button href="#schedule" variant="primary">Schedule Consultation</Button>
+      </div>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- Clarified that in-person pricing is determined case-by-case and added a schedule consultation button in the pricing section.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac8e5d6090832b80a32affac30c774