### PR TITLE
hook pricing schedule to cal modal

### DIFF
--- a/src/components/Pricing.tsx
+++ b/src/components/Pricing.tsx
@@ -3,9 +3,11 @@
 import PricingCard from './ui/PricingCard'
 import { siteContent } from '@/data/siteContent'
 import Button from './ui/Button'
+import { useCal } from './CalProvider'
 
 export default function Pricing () {
   const { heading, subheading, plans } = siteContent.pricing
+  const { open } = useCal()
   return (
     <section id="pricing" className="py-16 bg-background dark:bg-academic-navy">
       <div className="container mx-auto px-4">
@@ -25,7 +27,13 @@ export default function Pricing () {
         <p className="text-academic-medium-blue dark:text-academic-off-white mb-4">
           In-person pricing is determined on a case-by-case basis. Schedule a consultation to discuss options.
         </p>
-        <Button href="#schedule" variant="primary">Schedule Consultation</Button>
+        <Button
+          onClick={() => open('https://cal.com/thebayarea/consultation?embed=1')}
+          variant="primary"
+          className="schedule-trigger"
+        >
+          Schedule Now
+        </Button>
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
- open cal.com consultation modal from pricing schedule button

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac9091e9d4832ba1cd5d8e8d0880ab