### PR TITLE
Add rotating testimonials section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import Header from '@/components/Header'
 import Hero from '@/components/Hero'
 import Services from '@/components/Services'
 import About from '@/components/About'
+import Testimonials from '@/components/Testimonials'
 import Pricing from '@/components/Pricing'
 import FAQ from '@/components/FAQ'
 import Contact from '@/components/Contact'
@@ -15,6 +16,7 @@ export default function HomePage () {
                 <Hero />
                 <Services />
                 <About />
+                <Testimonials />
                 <Pricing />
                 <FAQ />
                 <Contact />

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { ChevronLeft, ChevronRight, Quote } from 'lucide-react'
+
+import { siteContent } from '@/data/siteContent'
+
+export default function Testimonials () {
+    const { heading, subheading, items } = siteContent.testimonials
+    const [ currentIndex, setCurrentIndex ] = useState(0)
+
+    useEffect(() => {
+        if (!items.length) {
+            return
+        }
+
+        const interval = setInterval(() => {
+            setCurrentIndex((prev) => (prev + 1) % items.length)
+        }, 8000)
+
+        return () => clearInterval(interval)
+    }, [items.length])
+
+    if (!items.length) {
+        return null
+    }
+
+    const currentTestimonial = items[currentIndex]
+
+    const handlePrevious = () => {
+        setCurrentIndex((prev) => (prev - 1 + items.length) % items.length)
+    }
+
+    const handleNext = () => {
+        setCurrentIndex((prev) => (prev + 1) % items.length)
+    }
+
+    return (
+        <section id="testimonials" className="py-20 lg:py-32 bg-zinc-100 dark:bg-academic-dark-blue/60">
+            <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+                <div className="text-center mb-12">
+                    <h2 className="text-3xl sm:text-4xl font-bold text-foreground dark:text-white mb-4 title-font">
+                        {heading}
+                    </h2>
+                    <p className="text-lg sm:text-xl text-academic-medium-blue dark:text-academic-off-white max-w-2xl mx-auto">
+                        {subheading}
+                    </p>
+                </div>
+
+                <div className="max-w-4xl mx-auto">
+                    <div className="relative bg-white dark:bg-academic-navy rounded-3xl shadow-xl p-8 sm:p-12 transition-all duration-500">
+                        <Quote className="w-10 h-10 text-academic-gold mb-6" />
+                        <blockquote className="text-xl sm:text-2xl font-medium text-foreground dark:text-white leading-relaxed">
+                            “{currentTestimonial.quote}”
+                        </blockquote>
+                        <div className="mt-8">
+                            <p className="text-lg font-semibold text-foreground dark:text-academic-off-white">
+                                {currentTestimonial.name}
+                            </p>
+                            <p className="text-sm uppercase tracking-wide text-academic-medium-blue dark:text-academic-off-white/70">
+                                {currentTestimonial.role}
+                            </p>
+                        </div>
+                        <div className="mt-10 flex items-center justify-between">
+                            <button
+                                type="button"
+                                onClick={handlePrevious}
+                                className="inline-flex h-12 w-12 items-center justify-center rounded-full border border-academic-gold text-academic-gold hover:bg-academic-gold hover:text-academic-navy transition-colors"
+                                aria-label="Show previous testimonial"
+                            >
+                                <ChevronLeft className="h-6 w-6" />
+                            </button>
+                            <div className="flex items-center space-x-2">
+                                {items.map((_, index) => (
+                                    <button
+                                        key={index}
+                                        type="button"
+                                        onClick={() => setCurrentIndex(index)}
+                                        className={`h-2.5 w-8 rounded-full transition-all ${index === currentIndex ? 'bg-academic-gold' : 'bg-academic-gold/30'}`}
+                                        aria-label={`Show testimonial ${index + 1}`}
+                                    />
+                                ))}
+                            </div>
+                            <button
+                                type="button"
+                                onClick={handleNext}
+                                className="inline-flex h-12 w-12 items-center justify-center rounded-full border border-academic-gold text-academic-gold hover:bg-academic-gold hover:text-academic-navy transition-colors"
+                                aria-label="Show next testimonial"
+                            >
+                                <ChevronRight className="h-6 w-6" />
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    )
+}

--- a/src/data/siteContent.ts
+++ b/src/data/siteContent.ts
@@ -102,8 +102,39 @@ export const siteContent: SiteContent = {
                     "Preparation for college-level mathematics"
                 ]
             }
-        
+
         ],
+    },
+    testimonials: {
+        heading: "Families See the Difference",
+        subheading: "Hear from parents and students who have experienced measurable improvements",
+        items: [
+            {
+                name: "Sarah L.",
+                role: "Parent of 11th Grader",
+                quote: "Within a semester, my son's confidence in calculus skyrocketed. He went from struggling to maintaining a solid A and now actually enjoys the subject."
+            },
+            {
+                name: "Ethan R.",
+                role: "AP Physics Student",
+                quote: "The focused test prep and weekly feedback helped me earn a 5 on the AP Physics exam. The strategies we practiced made the test feel manageable."
+            },
+            {
+                name: "Priya K.",
+                role: "Parent of 9th Grader",
+                quote: "We saw noticeable improvements after just a few sessions. Assignments were completed on time, and the stress around math homework disappeared."
+            },
+            {
+                name: "Lucas A.",
+                role: "SAT Test Taker",
+                quote: "I improved my SAT Math score by over 150 points. The personalized practice sets and review sessions were exactly what I needed."
+            },
+            {
+                name: "Angela M.",
+                role: "Parent of 12th Grader",
+                quote: "Amir's mentorship extended beyond academics. He kept our daughter motivated through college application season and helped her stay on track with AP coursework."
+            }
+        ]
     },
     locations: {
         heading: "Tutoring Locations",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,6 +38,12 @@ export interface FAQ {
     answer: string;
 }
 
+export interface Testimonial {
+    name: string;
+    role: string;
+    quote: string;
+}
+
 export interface StudentResult {
     id: string;
     beforeGrade: string;
@@ -79,6 +85,11 @@ export interface SiteContent {
         heading: string;
         subheading: string;
         items: Service[];
+    };
+    testimonials: {
+        heading: string;
+        subheading: string;
+        items: Testimonial[];
     };
     locations: {
         heading: string;


### PR DESCRIPTION
## Summary
- add typed testimonials data to the shared site content object
- create an auto-rotating testimonials section with manual navigation controls
- include the testimonials section on the homepage layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca3d11859c832ba99143b5b1e0cfa4